### PR TITLE
Align RIM implementation with canonical reward model

### DIFF
--- a/atlas/config/models.py
+++ b/atlas/config/models.py
@@ -186,7 +186,8 @@ class StudentConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    prompts: StudentPrompts
+    prompts: StudentPrompts | None = None
+    prompt_guidance: Dict[str, str] = Field(default_factory=dict)
     max_plan_tokens: int = Field(default=2048, ge=1)
     max_step_tokens: int = Field(default=2048, ge=1)
     max_synthesis_tokens: int = Field(default=2048, ge=1)
@@ -202,7 +203,8 @@ class TeacherConfig(BaseModel):
     plan_cache_seconds: int = Field(default=300, ge=0)
     guidance_max_tokens: int = Field(default=512, ge=1)
     validation_max_tokens: int = Field(default=512, ge=1)
-    prompts: "TeacherPrompts" = Field(default_factory=lambda: TeacherPrompts())
+    prompts: TeacherPrompts | None = None
+    prompt_guidance: Dict[str, str] = Field(default_factory=dict)
 
 class JudgeKind(str, Enum):
     """Judge families aggregated within RIM."""

--- a/atlas/orchestration/orchestrator.py
+++ b/atlas/orchestration/orchestrator.py
@@ -61,32 +61,62 @@ class Orchestrator:
         reviewed_plan = await self._teacher.areview_plan(task, initial_plan)
         context.metadata["task"] = task
         context.metadata["plan"] = reviewed_plan.model_dump()
-        execution_order = self._determine_order(reviewed_plan)
+        levels = self._determine_levels(reviewed_plan)
         context_outputs: Dict[int, str] = {}
         step_summaries: List[Dict[str, Any]] = []
         step_results: List[StepResult] = []
-        for step_id in execution_order:
-            step = self._lookup_step(reviewed_plan, step_id)
-            result, evaluation, attempts = await self._run_step(task, step, context_outputs, context)
-            context_outputs[step.id] = result.output
-            step_payload = {
-                "step_id": step.id,
-                "description": step.description,
-                "output": result.output,
-                "trace": result.trace,
-                "evaluation": evaluation,
-                "attempts": attempts,
-            }
-            step_summaries.append(step_payload)
-            step_results.append(
-                StepResult(
-                    step_id=step.id,
-                    trace=result.trace,
-                    output=result.output,
-                    evaluation=evaluation,
-                    attempts=attempts,
+        for level in levels:
+            if len(level) == 1:
+                step_id = level[0]
+                step = self._lookup_step(reviewed_plan, step_id)
+                result, evaluation, attempts = await self._run_step(task, step, context_outputs, context)
+                context_outputs[step.id] = result.output
+                step_summaries.append(
+                    {
+                        "step_id": step.id,
+                        "description": step.description,
+                        "output": result.output,
+                        "trace": result.trace,
+                        "evaluation": evaluation,
+                        "attempts": attempts,
+                    }
                 )
-            )
+                step_results.append(
+                    StepResult(
+                        step_id=step.id,
+                        trace=result.trace,
+                        output=result.output,
+                        evaluation=evaluation,
+                        attempts=attempts,
+                    )
+                )
+            else:
+                steps = [self._lookup_step(reviewed_plan, step_id) for step_id in level]
+                results = await asyncio.gather(
+                    *(self._run_step(task, step, context_outputs, context) for step in steps)
+                )
+                for step, outcome in zip(steps, results):
+                    result, evaluation, attempts = outcome
+                    context_outputs[step.id] = result.output
+                    step_summaries.append(
+                        {
+                            "step_id": step.id,
+                            "description": step.description,
+                            "output": result.output,
+                            "trace": result.trace,
+                            "evaluation": evaluation,
+                            "attempts": attempts,
+                        }
+                    )
+                    step_results.append(
+                        StepResult(
+                            step_id=step.id,
+                            trace=result.trace,
+                            output=result.output,
+                            evaluation=evaluation,
+                            attempts=attempts,
+                        )
+                    )
         organized_results = self._teacher.collect_results(step_summaries)
         final_answer = await self._student.asynthesize_final_answer(task, organized_results)
         manager.push_intermediate_step(
@@ -245,15 +275,9 @@ class Orchestrator:
             return attempts <= self._orchestration.max_retries
         return score < self._rim_config.retry_threshold and attempts <= self._orchestration.max_retries
 
-    def _determine_order(self, plan: Plan) -> List[int]:
+    def _determine_levels(self, plan: Plan) -> List[List[int]]:
         graph = DependencyGraph(plan)
-        levels = graph.topological_levels()
-        ordered: List[int] = []
-        for level in levels:
-            if len(level) != 1:
-                raise ValueError("Parallel execution is not supported in the sequential orchestrator")
-            ordered.append(level[0])
-        return ordered
+        return graph.topological_levels()
 
     def _lookup_step(self, plan: Plan, step_id: int) -> Step:
         for step in plan.steps:

--- a/atlas/orchestration/orchestrator.py
+++ b/atlas/orchestration/orchestrator.py
@@ -44,6 +44,7 @@ class Orchestrator:
         self._evaluator = evaluator
         self._orchestration = orchestration_config
         self._rim_config = rim_config
+        self._rim_retry_threshold = getattr(rim_config, "retry_threshold", 0.6)
 
     async def arun(self, task: str) -> Result:
         context = ExecutionContext.get()
@@ -273,7 +274,7 @@ class Orchestrator:
             return False
         if not validation.get("valid", False):
             return attempts <= self._orchestration.max_retries
-        return score < self._rim_config.retry_threshold and attempts <= self._orchestration.max_retries
+        return score < self._rim_retry_threshold and attempts <= self._orchestration.max_retries
 
     def _determine_levels(self, plan: Plan) -> List[List[int]]:
         graph = DependencyGraph(plan)

--- a/atlas/reward/helpfulness_judge.py
+++ b/atlas/reward/helpfulness_judge.py
@@ -5,22 +5,24 @@ from __future__ import annotations
 import json
 from typing import Dict, Sequence
 
-from atlas.config.models import JudgeConfig
 from atlas.reward.judge import Judge, JudgeContext
 from atlas.reward.judge_prompts import HELPFULNESS_PROMPT
+from atlas.utils.llm_client import LLMClient
 
 
 class HelpfulnessJudge(Judge):
-    def __init__(self, config: JudgeConfig) -> None:
-        super().__init__(config)
+    def __init__(self, client: LLMClient) -> None:
+        super().__init__("helpfulness", client)
 
-    async def ajudge(self, context: JudgeContext):  # pragma: no cover - evaluator drives outcomes
-        raise NotImplementedError("HelpfulnessJudge outcomes are computed by the evaluator")
+    async def ajudge(self, context: JudgeContext):  # pragma: no cover - evaluator orchestrates outcomes
+        raise NotImplementedError("Evaluator controls helpfulness judge aggregation")
 
     def _build_messages(self, context: JudgeContext) -> Sequence[Dict[str, str]]:
         system_prompt = HELPFULNESS_PROMPT.format(
             task=context.task,
-            teacher_trace=json.dumps(context.guidance or [], ensure_ascii=False, indent=2),
+            step_id=context.step.id,
+            step_description=context.step.description,
+            guidance=json.dumps(list(context.guidance or []), ensure_ascii=False, indent=2),
             student_trace=context.trace,
             student_output=context.output,
             prior_results=json.dumps(context.prior_results or {}, ensure_ascii=False, indent=2),
@@ -31,13 +33,11 @@ class HelpfulnessJudge(Judge):
             "execution_trace": context.trace,
             "final_output": context.output,
             "prior_step_results": context.prior_results or {},
+            "guidance_history": list(context.guidance or []),
         }
         return [
             {"role": "system", "content": system_prompt},
-            {
-                "role": "user",
-                "content": json.dumps(payload, ensure_ascii=False) + "\nReturn json.",
-            },
+            {"role": "user", "content": json.dumps(payload, ensure_ascii=False)},
         ]
 
     def build_meta_prompt(self, context: JudgeContext, samples, escalation_reason: str | None) -> str:
@@ -51,27 +51,21 @@ class HelpfulnessJudge(Judge):
                 for i, sample in enumerate(samples)
             )
         else:
-            sample_text = "Tier-1 judges did not produce usable outputs."
+            sample_text = "Tier-1 judges produced no parsable output; escalating directly to you."
 
-        reason_text = f"Escalation reason: {escalation_reason}\n" if escalation_reason else "Escalation triggered by high variance / uncertainty.\n"
-
-        guidance_text = json.dumps(context.guidance or [], ensure_ascii=False)
+        reason_text = (
+            f"Escalation reason: {escalation_reason}\n" if escalation_reason else "Escalation triggered by disagreement or high uncertainty.\n"
+        )
 
         return (
-            "You are the escalation arbiter for teaching helpfulness. Tier-1 judges disagreed or were uncertain"
-            " about how effective the teacher's guidance was.\n\n"
+            "SYSTEM: You are the Atlas Teaching Helpfulness Arbiter. Tier-1 judges are uncertain about the guidance"
+            " impact. Review their work and deliver the final judgement.\n\n"
             f"{reason_text}Task: {context.task}\n"
-            f"Teacher Guidance: {guidance_text}\n"
+            f"Step Description: {context.step.description}\n"
             f"Student Execution Trace: {context.trace}\n"
             f"Student Output: {context.output}\n\n"
             "Tier-1 evaluations (principles, score, uncertainty, rationale):\n"
             f"{sample_text}\n\n"
-            "Instructions:\n"
-            "1. Analyse the principles used by the tier-1 judges. Identify agreements, conflicts, or omissions.\n"
-            "2. Reuse the strongest principles or create new ones that better capture helpfulness in this context.\n"
-            "3. Re-evaluate the guidance versus the student's outcome using your chosen principles.\n"
-            "4. Provide a final score in [0,1] with rationale tied to each selected principle.\n"
-            "5. Report an uncertainty value in [0,1].\n\n"
-            "Return JSON {{\"principles\": [{{\"name\": str, \"weight\": float, \"description\": str}}],"
-            " \"score\": float, \"rationale\": str, \"uncertainty\": float}}."
+            "Output JSON with keys principles, score, rationale, uncertainty. Explain how you reconciled conflicts,"
+            " identified missed opportunities in the guidance, and whether escalation to a human teacher is required."
         )

--- a/atlas/reward/process_judge.py
+++ b/atlas/reward/process_judge.py
@@ -5,23 +5,27 @@ from __future__ import annotations
 import json
 from typing import Dict, Sequence
 
-from atlas.config.models import JudgeConfig
 from atlas.reward.judge import Judge, JudgeContext
 from atlas.reward.judge_prompts import PROCESS_PROMPT
+from atlas.utils.llm_client import LLMClient
 
 
 class ProcessJudge(Judge):
-    def __init__(self, config: JudgeConfig) -> None:
-        super().__init__(config)
+    def __init__(self, client: LLMClient) -> None:
+        super().__init__("process", client)
 
-    async def ajudge(self, context: JudgeContext):  # pragma: no cover - orchestrator uses samples instead
-        raise NotImplementedError("ProcessJudge outcomes are computed by the evaluator")
+    async def ajudge(self, context: JudgeContext):
+        raise NotImplementedError("Evaluator controls process judge aggregation")
 
     def _build_messages(self, context: JudgeContext) -> Sequence[Dict[str, str]]:
         system_prompt = PROCESS_PROMPT.format(
+            task=context.task,
+            step_id=context.step.id,
             step_description=context.step.description,
             dependencies=json.dumps(context.step.depends_on, ensure_ascii=False),
-            guidance=json.dumps(context.guidance or [], ensure_ascii=False, indent=2),
+            attempt=context.attempt,
+            guidance=json.dumps(list(context.guidance or []), ensure_ascii=False, indent=2),
+            prior_results=json.dumps(context.prior_results or {}, ensure_ascii=False, indent=2),
             student_trace=context.trace,
             student_output=context.output,
         )
@@ -31,13 +35,11 @@ class ProcessJudge(Judge):
             "final_output": context.output,
             "attempt": context.attempt,
             "prior_results": context.prior_results or {},
+            "guidance_history": list(context.guidance or []),
         }
         return [
             {"role": "system", "content": system_prompt},
-            {
-                "role": "user",
-                "content": json.dumps(payload, ensure_ascii=False) + "\nReturn json.",
-            },
+            {"role": "user", "content": json.dumps(payload, ensure_ascii=False)},
         ]
 
     def build_meta_prompt(self, context: JudgeContext, samples, escalation_reason: str | None) -> str:
@@ -51,25 +53,23 @@ class ProcessJudge(Judge):
                 for i, sample in enumerate(samples)
             )
         else:
-            sample_text = "Tier-1 judges did not produce usable outputs."
+            sample_text = "Tier-1 judges produced no parsable output; escalating directly to you."
 
-        reason_text = f"Escalation reason: {escalation_reason}\n" if escalation_reason else "Escalation triggered by high variance / uncertainty.\n"
+        reason_text = (
+            f"Escalation reason: {escalation_reason}\n" if escalation_reason else "Escalation triggered by disagreement or high uncertainty.\n"
+        )
 
         return (
-            "You are the escalation arbiter for process quality. Tier-1 judges disagreed or were uncertain about this"
-            " step. Review their outputs and issue a final judgment.\n\n"
-            f"{reason_text}Step Description: {context.step.description}\n"
+            "SYSTEM: You are the Atlas Process Arbiter. Tier-1 judges disagreed about this execution attempt."
+            " Review their evaluations and deliver the final judgement.\n\n"
+            f"{reason_text}Task: {context.task}\n"
+            f"Step ID: {context.step.id}\n"
+            f"Step Description: {context.step.description}\n"
             f"Execution Trace: {context.trace}\n"
-            f"Final Output: {context.output}\n\n"
+            f"Student Output: {context.output}\n\n"
             "Tier-1 evaluations (principles, score, uncertainty, rationale):\n"
             f"{sample_text}\n\n"
-            "Instructions:\n"
-            "1. Compare the tier-1 principles and rationales. Identify conflicts or gaps.\n"
-            "2. Decide which principles remain valid; create new principles if conflicts cannot be resolved.\n"
-            "3. Using the best set of principles, reassess the execution trace in light of the teacher guidance and"
-            " final output.\n"
-            "4. Produce a final score in [0,1] with a detailed rationale referencing each selected principle.\n"
-            "5. Report an uncertainty value in [0,1].\n\n"
-            "Return JSON {{\"principles\": [{{\"name\": str, \"weight\": float, \"description\": str}}],"
-            " \"score\": float, \"rationale\": str, \"uncertainty\": float}}."
+            "Output JSON with keys principles, score, rationale, uncertainty. Apply your own high-fidelity principles"
+            " when synthesising the final result. Ensure the rationale explains how you reconciled conflicts and"
+            " addressed compliance or safety concerns."
         )

--- a/atlas/transition/rewriter.py
+++ b/atlas/transition/rewriter.py
@@ -2,18 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
-import re
 from dataclasses import dataclass
-from typing import Any, Dict, Sequence
+from typing import Any, Dict, List
 
-from atlas.config.models import (
-    AdapterConfig,
-    PromptRewriteConfig,
-    StudentConfig,
-    TeacherConfig,
-)
+from atlas.config.models import AdapterConfig, PromptRewriteConfig, StudentConfig, TeacherConfig
 from atlas.config.models import LLMParameters
 from atlas.utils.llm_client import LLMClient
 
@@ -30,6 +25,16 @@ class RewrittenTeacherPrompts:
     plan_review: str
     validation: str
     guidance: str
+
+
+@dataclass(frozen=True)
+class PersonaSpec:
+    family: str
+    output_key: str
+    title: str
+    focus: str
+    deliverables: List[str]
+    constraints: List[str]
 
 
 class PromptRewriteEngine:
@@ -57,192 +62,291 @@ class PromptRewriteEngine:
         student_config: StudentConfig,
         teacher_config: TeacherConfig,
     ) -> tuple[RewrittenStudentPrompts, RewrittenTeacherPrompts]:
-        cache_key = self._cache_key(base_prompt, adapter_config, student_config, teacher_config)
+        context = self._build_context(base_prompt, adapter_config, student_config, teacher_config)
+        cache_key = self._cache_key(context)
         if cache_key in self._cache:
             return self._cache[cache_key]
-
-        payload = self._build_payload(base_prompt, adapter_config, student_config, teacher_config)
-        messages = [
-            {
-                "role": "system",
-                "content": (
-                    "You rewrite system prompts for a multi-agent architecture. Preserve the user's intent and domain"
-                    " instructions exactly, while producing specialised prompts for a planner Student, an executor"
-                    " Student, and a Teacher reviewer.\n\n"
-                    "CRITICAL: You MUST return a JSON object with this EXACT structure:\n"
-                    "{\n"
-                    '  "student": {\n'
-                    '    "planner": "<planner prompt>",\n'
-                    '    "executor": "<executor prompt>",\n'
-                    '    "synthesizer": "<synthesizer prompt>"\n'
-                    "  },\n"
-                    '  "teacher": {\n'
-                    '    "plan_review": "<plan review prompt>",\n'
-                    '    "validation": "<validation prompt>",\n'
-                    '    "guidance": "<guidance prompt>"\n'
-                    "  }\n"
-                    "}\n\n"
-                    "Use ONLY these keys: 'student', 'teacher', 'planner', 'executor', 'synthesizer', "
-                    "'plan_review', 'validation', 'guidance'. Do NOT use alternative key names."
-                ),
-            },
-            {
-                "role": "user",
-                "content": json.dumps(payload, ensure_ascii=False, indent=2),
-            },
-        ]
-
-        response = await self._client.acomplete(
-            messages,
-            response_format={"type": "json_object"},
-            overrides={"max_tokens": self._max_tokens, "temperature": self._temperature},
+        specs = self._persona_specs()
+        persona_prompts = await asyncio.gather(
+            *(self._rewrite_persona(context, spec) for spec in specs)
         )
+        student_mapping: Dict[str, str] = {}
+        teacher_mapping: Dict[str, str] = {}
+        for spec, prompt_text in zip(specs, persona_prompts):
+            if spec.family == "student":
+                student_mapping[spec.output_key] = prompt_text
+            else:
+                teacher_mapping[spec.output_key] = prompt_text
 
-        if not response.content or not response.content.strip():
-            raise ValueError(
-                f"Prompt rewrite LLM returned empty response. "
-                f"Raw response object: {response.raw}"
+        try:
+            student_prompts = RewrittenStudentPrompts(
+                planner=student_mapping["planner"],
+                executor=student_mapping["executor"],
+                synthesizer=student_mapping["synthesizer"],
             )
+            teacher_prompts = RewrittenTeacherPrompts(
+                plan_review=teacher_mapping["plan_review"],
+                validation=teacher_mapping["validation"],
+                guidance=teacher_mapping["guidance"],
+            )
+        except KeyError as exc:
+            missing = str(exc)
+            raise ValueError(f"Prompt rewrite missing persona output {missing}") from exc
 
-        prompts = self._parse_response(response.content)
+        prompts = (student_prompts, teacher_prompts)
         self._cache[cache_key] = prompts
         return prompts
 
-    def _build_payload(
+    def _build_context(
         self,
         base_prompt: str,
         adapter_config: AdapterConfig,
         student_config: StudentConfig,
         teacher_config: TeacherConfig,
     ) -> Dict[str, Any]:
-        tools = []
+        tool_catalog = []
         for tool in getattr(adapter_config, "tools", []) or []:
-            tools.append(
+            tool_catalog.append(
                 {
                     "name": tool.name,
                     "description": tool.description,
                     "parameters": tool.parameters.model_dump(by_alias=True),
+                    "output_schema": tool.output_schema,
                 }
             )
 
-        student_instructions = student_config.prompts.model_dump() if getattr(student_config, "prompts", None) else {}
-        teacher_instructions = teacher_config.prompts.model_dump() if getattr(teacher_config, "prompts", None) else {}
+        adapter_snapshot = {
+            "type": getattr(getattr(adapter_config, "type", None), "value", None),
+            "name": getattr(adapter_config, "name", None),
+        }
+
+        student_settings = {
+            "tool_choice": student_config.tool_choice,
+            "guidance": dict(student_config.prompt_guidance or {}),
+        }
+
+        teacher_settings = {
+            "plan_cache_seconds": teacher_config.plan_cache_seconds,
+            "guidance": dict(teacher_config.prompt_guidance or {}),
+        }
 
         return {
             "base_agent_prompt": base_prompt,
-            "available_tools": tools,
-            "student_prompt_guidance": student_instructions,
-            "teacher_prompt_guidance": teacher_instructions,
-            "expect_output_schema": {
-                "student": ["planner", "executor", "synthesizer"],
-                "teacher": ["plan_review", "validation", "guidance"],
-            },
-            "notes": (
-                "Generate concise, fully-specified system prompts. Planner must emit JSON where each step entry includes"
-                " the keys id (integer), description (string), depends_on (list of integers), tool (string or null),"
-                " and tool_params (object or null) only. Steps must form a strictly sequential chain: step 1 has no"
-                " dependencies, step 2 depends on [1], step 3 depends on [2], etc. No parallel execution is allowed."
-                " Executor should follow plans with precise instructions for tool usage; teacher should review, validate,"
-                " and provide remediation guidance. Maintain the tone and constraints of the base agent prompt."
-            ),
+            "adapter": adapter_snapshot,
+            "tool_catalog": tool_catalog,
+            "student": student_settings,
+            "teacher": teacher_settings,
         }
 
-    def _extract_json(self, content: str) -> dict | None:
-        """Extract JSON from LLM response, handling markdown code fences and extra text."""
-        content_stripped = content.strip()
-
-        try:
-            return json.loads(content_stripped)
-        except json.JSONDecodeError:
-            pass
-
-        patterns = [
-            r'```json\s*\n(.*?)\n```',
-            r'```\s*\n(.*?)\n```',
+    def _persona_specs(self) -> List[PersonaSpec]:
+        return [
+            PersonaSpec(
+                family="student",
+                output_key="planner",
+                title="Planner Student",
+                focus=(
+                    "Transform tasks into an ordered JSON plan with dependencies."
+                    " Ensure independent steps are clearly tagged so the orchestrator"
+                    " can execute them in parallel while respecting prerequisites."
+                ),
+                deliverables=[
+                    "Structured plan enumerating steps with ids, descriptions, dependencies, and tool usage recommendations",
+                    "Explicit parallelisation cues highlighting which steps may run concurrently",
+                    "Pre-flight validations covering resource, compliance, and context requirements",
+                ],
+                constraints=[
+                    "Must not drop user constraints or domain-specific guardrails from the base prompt",
+                    "Identify prerequisites for every step and call out missing data or permissions",
+                    "Avoid unapproved tools or actions that violate compliance or platform policies",
+                ],
+            ),
+            PersonaSpec(
+                family="student",
+                output_key="executor",
+                title="Executor Student",
+                focus=(
+                    "Execute a single plan step using available tools and prior context."
+                    " Instructions must remain correct even when multiple independent"
+                    " steps execute simultaneously in separate threads of work."
+                ),
+                deliverables=[
+                    "Detailed execution methodology referencing approved tools and inputs",
+                    "Concurrency-safe context handling and conflict resolution guidance",
+                    "Structured logging expectations for telemetry and audits",
+                ],
+                constraints=[
+                    "Never invoke disallowed operations or unreviewed integrations",
+                    "Respect rate limits, data classification, and compliance policies",
+                    "Escalate or pause when prerequisites from peer steps are missing",
+                ],
+            ),
+            PersonaSpec(
+                family="student",
+                output_key="synthesizer",
+                title="Synthesizer Student",
+                focus=(
+                    "Aggregate completed step outputs into a final response."
+                    " Honour every constraint from the base agent prompt and cite"
+                    " the contributing steps while reconciling concurrent results."
+                ),
+                deliverables=[
+                    "Structured summary that references contributing step ids and evidence",
+                    "Risk, uncertainty, and follow-up sections for unresolved items",
+                    "Format guidance for citations, provenance, and final answer shape",
+                ],
+                constraints=[
+                    "Final output must maintain tone and formatting requirements from the base prompt",
+                    "Do not manufacture facts; rely only on validated step outputs or flag gaps",
+                    "Include remediation or escalation instructions when success criteria are unmet",
+                ],
+            ),
+            PersonaSpec(
+                family="teacher",
+                output_key="plan_review",
+                title="Plan Review Teacher",
+                focus=(
+                    "Audit the student plan for completeness, correctness, and"
+                    " concurrency readiness. Enforce valid dependencies so only"
+                    " independent steps run in parallel."
+                ),
+                deliverables=[
+                    "Assessment rubric covering completeness, dependency integrity, risk, and compliance",
+                    "Rewritten plan when deficiencies are found, maintaining original context",
+                    "Approval or rejection decision with justification",
+                ],
+                constraints=[
+                    "Cache results according to plan_cache_seconds to avoid redundant approvals",
+                    "Spot and forbid hidden circular dependencies or missing prerequisites",
+                    "Flag requirements for human review when risks exceed thresholds",
+                ],
+            ),
+            PersonaSpec(
+                family="teacher",
+                output_key="validation",
+                title="Validation Teacher",
+                focus=(
+                    "Validate execution traces and outputs for each step,"
+                    " considering that peer steps may complete in parallel."
+                    " Return structured judgements aligned with the RIM judges."
+                ),
+                deliverables=[
+                    "Deterministic {\"valid\": bool, \"rationale\": str} assessments aligned with orchestration schema",
+                    "Callouts for concurrency conflicts, missing evidence, or safety breaches",
+                    "Signal data for RIM judges including process and helpfulness cues",
+                ],
+                constraints=[
+                    "Produce actionable rationales that downstream systems can parse",
+                    "Reference telemetry traces, tool outputs, and guidance history",
+                    "Escalate when evidence is insufficient or policies are violated",
+                ],
+            ),
+            PersonaSpec(
+                family="teacher",
+                output_key="guidance",
+                title="Guidance Teacher",
+                focus=(
+                    "Produce concise remediation guidance that helps the executor"
+                    " correct mistakes on the next retry while remaining aware of"
+                    " concurrent workstreams."
+                ),
+                deliverables=[
+                    "Targeted remediation steps prioritised for the next attempt",
+                    "Tool usage or research recommendations gated by policy",
+                    "Signals for when to request human assistance or expand scope",
+                ],
+                constraints=[
+                    "Avoid duplicating stale advice and reference the most recent teacher feedback",
+                    "Highlight dependencies on parallel steps and suggest coordination tactics",
+                    "Maintain tone consistent with the base prompt and organisational policies",
+                ],
+            ),
         ]
 
-        for pattern in patterns:
-            match = re.search(pattern, content, re.DOTALL)
-            if match:
-                json_str = match.group(1).strip()
-                try:
-                    return json.loads(json_str)
-                except json.JSONDecodeError:
-                    continue
+    async def _rewrite_persona(self, context: Dict[str, Any], spec: PersonaSpec) -> str:
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    "You design production-grade system instructions for an Atlas persona."
+                    " Always preserve the provided base_agent_prompt verbatim at the top of"
+                    " the final prompt. Append persona-specific guidance that is exhaustive"
+                    " enough for enterprise workflows."
+                    "\n\n"
+                    "The appended guidance must follow this format, using uppercase section"
+                    " titles:"
+                    "\n1. ROLE OVERVIEW"
+                    "\n2. PRIMARY OBJECTIVES"
+                    "\n3. EXECUTION DIRECTIVES"
+                    "\n4. SAFETY AND COMPLIANCE"
+                    "\n5. COLLABORATION AND HANDOFFS"
+                    "\n6. QUALITY BAR"
+                    "\n7. FAILURE AND ESCALATION"
+                    "\nEach section should contain clear sentences or numbered directives."
+                    " Incorporate every deliverable and constraint provided. Reflect the"
+                    " persona focus, concurrency guarantees, tool catalog, and token limits."
+                    " Do not emit markdown fences, JSON, or bullet characters other than"
+                    " numbers or dashes where appropriate."
+                ),
+            },
+            {
+                "role": "user",
+                "content": json.dumps(self._persona_payload(context, spec), ensure_ascii=False, indent=2),
+            },
+        ]
+        response = await self._client.acomplete(
+            messages,
+            overrides={"max_tokens": self._max_tokens, "temperature": self._temperature},
+        )
+        addition = response.content.strip()
+        if not addition:
+            raise ValueError(f"Prompt rewrite produced empty instructions for {spec.title}")
+        base_prompt = context["base_agent_prompt"].strip()
+        if addition.startswith(base_prompt):
+            trimmed = addition[len(base_prompt):].lstrip()
+        else:
+            trimmed = addition
+        if base_prompt and trimmed:
+            combined = f"{base_prompt}\n\n{trimmed}"
+        else:
+            combined = base_prompt or trimmed
+        return combined
 
-        first_brace = content.find('{')
-        if first_brace != -1:
-            try:
-                return json.loads(content[first_brace:])
-            except json.JSONDecodeError:
-                pass
+    def _persona_payload(self, context: Dict[str, Any], spec: PersonaSpec) -> Dict[str, Any]:
+        if spec.family == "student":
+            guidance = context["student"]["guidance"].get(spec.output_key)
+        else:
+            guidance = context["teacher"]["guidance"].get(spec.output_key)
 
-            depth = 0
-            for i in range(first_brace, len(content)):
-                if content[i] == '{':
-                    depth += 1
-                elif content[i] == '}':
-                    depth -= 1
-                    if depth == 0:
-                        try:
-                            return json.loads(content[first_brace:i+1])
-                        except json.JSONDecodeError:
-                            break
+        return {
+            "persona": {
+                "family": spec.family,
+                "output_key": spec.output_key,
+                "title": spec.title,
+                "focus": spec.focus,
+                "additional_guidance": guidance,
+                "deliverables": spec.deliverables,
+                "constraints": spec.constraints,
+            },
+            "base_agent_prompt": context["base_agent_prompt"],
+            "adapter": context["adapter"],
+            "tool_catalog": context["tool_catalog"],
+            "student_settings": context["student"],
+            "teacher_settings": context["teacher"],
+            "concurrency_requirements": {
+                "independent_steps_may_execute_in_parallel": True,
+                "expect_exact_dependency_tracking": True,
+            },
+            "output_expectation": {
+                "format": "plain_text",
+                "must_preserve_base_prompt": True,
+                "forbidden_styles": ["json", "markdown_fence"],
+            },
+        }
 
-        return None
-
-    def _parse_response(
-        self,
-        content: str,
-    ) -> tuple[RewrittenStudentPrompts, RewrittenTeacherPrompts]:
-        data = self._extract_json(content)
-        if data is None:
-            raise ValueError(
-                f"Prompt rewrite LLM response was not valid JSON. "
-                f"Response preview: {content[:500]}"
-            )
-
-        try:
-            student = data.get("student") or data.get("student_prompts")
-            teacher = data.get("teacher") or data.get("teacher_prompts")
-            if not student or not teacher:
-                raise KeyError("Missing student or teacher sections")
-        except (KeyError, AttributeError) as exc:
-            raise ValueError(
-                f"Prompt rewrite JSON missing required sections. "
-                f"Found keys: {list(data.keys()) if isinstance(data, dict) else 'not a dict'}"
-            ) from exc
-
-        try:
-            student_prompts = RewrittenStudentPrompts(
-                planner=str(student["planner"]),
-                executor=str(student["executor"]),
-                synthesizer=str(student["synthesizer"]),
-            )
-            teacher_prompts = RewrittenTeacherPrompts(
-                plan_review=str(teacher["plan_review"]),
-                validation=str(teacher["validation"]),
-                guidance=str(teacher["guidance"]),
-            )
-        except KeyError as exc:
-            raise ValueError("Prompt rewrite JSON missing expected keys") from exc
-
-        return student_prompts, teacher_prompts
-
-    def _cache_key(
-        self,
-        base_prompt: str,
-        adapter_config: AdapterConfig,
-        student_config: StudentConfig,
-        teacher_config: TeacherConfig,
-    ) -> str:
+    def _cache_key(self, context: Dict[str, Any]) -> str:
         digest = hashlib.sha256()
-        digest.update(base_prompt.strip().encode("utf-8"))
-        digest.update(json.dumps([tool.name for tool in getattr(adapter_config, "tools", []) or []]).encode("utf-8"))
-        if getattr(student_config, "prompts", None):
-            digest.update(json.dumps(student_config.prompts.model_dump(), sort_keys=True).encode("utf-8"))
-        if getattr(teacher_config, "prompts", None):
-            digest.update(json.dumps(teacher_config.prompts.model_dump(), sort_keys=True).encode("utf-8"))
+        serialized = json.dumps(context, ensure_ascii=False, sort_keys=True)
+        digest.update(serialized.encode("utf-8"))
         return digest.hexdigest()
 
 

--- a/configs/examples/gdpval_python.yaml
+++ b/configs/examples/gdpval_python.yaml
@@ -96,41 +96,21 @@ orchestration:
   emit_intermediate_steps: true
 
 rim:
-  judges:
-    - identifier: factuality
-      kind: helpfulness
-      weight: 0.5
-      principles:
-        - Cite specific evidence from GDPval references for every claim.
-      llm:
-        provider: google
-        model: gemini/gemini-2.5-flash
-        api_key_env: GEMINI_API_KEY
-        temperature: 0.05
-        max_output_tokens: 8192
-    - identifier: rigor
-      kind: process
-      weight: 0.5
-      principles:
-        - Validate reasoning steps for completeness and economic soundness.
-      llm:
-        provider: google
-        model: gemini/gemini-2.5-flash
-        api_key_env: GEMINI_API_KEY
-        temperature: 0.05
-        max_output_tokens: 8192
-  temperatures: [0.0, 0.2]
-  variance_threshold: 0.2
-  uncertainty_threshold: 0.35
-  arbiter:
+  small_model:
+    provider: google
+    model: gemini/gemini-2.5-flash
+    api_key_env: GEMINI_API_KEY
+    max_output_tokens: 8192
+  large_model:
     provider: google
     model: gemini/gemini-2.5-pro
     api_key_env: GEMINI_API_KEY
-    temperature: 1.0
     max_output_tokens: 8192
-  success_threshold: 0.8
-  retry_threshold: 0.6
-  aggregation_strategy: weighted_mean
+  active_judges:
+    process: true
+    helpfulness: true
+  variance_threshold: 0.2
+  uncertainty_threshold: 0.35
 
 storage:
   database_url: postgresql://atlas:atlas@localhost:5433/atlas

--- a/configs/examples/gdpval_python.yaml
+++ b/configs/examples/gdpval_python.yaml
@@ -59,26 +59,6 @@ agent:
       OpenAI-Beta: reasoning=1
 
 student:
-  prompts:
-    planner: |
-      {base_prompt}
-
-      You are preparing a GDPval analysis for the {metadata[sector]} sector ({metadata[occupation]} occupation).
-      Construct a plan that enumerates each reasoning step, specifies which reference documents are required,
-      and highlights any missing sources that should be reviewed. Output JSON with fields: step_id, description,
-      references_needed (filenames), and dependencies.
-    executor: |
-      {base_prompt}
-
-      You are executing step {{step_id}} for the {metadata[sector]} sector ({metadata[occupation]} occupation).
-      Use the tools to inspect the required references (list_references, read_reference, summarize_reference)
-      and synthesize findings grounded in the cited files. Report the outcome, citing filenames inline.
-    synthesizer: |
-      {base_prompt}
-
-      Summarize the completed work for the {metadata[sector]} sector ({metadata[occupation]} occupation).
-      Provide a concise validation report pulling key evidence from the referenced documents. Cite filenames and
-      highlight uncertainties or missing evidence where applicable.
   max_plan_tokens: 32000
   max_step_tokens: 32000
   max_synthesis_tokens: 32000

--- a/configs/examples/http_agent.yaml
+++ b/configs/examples/http_agent.yaml
@@ -64,41 +64,21 @@ orchestration:
   emit_intermediate_steps: true
 
 rim:
-  judges:
-    - identifier: process
-      kind: process
-      weight: 0.5
-      principles:
-        - Procedural accuracy
-      llm:
-        provider: openai
-        model: gpt-4o-mini
-        api_key_env: OPENAI_API_KEY
-        temperature: 0.0
-        max_output_tokens: 512
-    - identifier: helpfulness
-      kind: helpfulness
-      weight: 0.5
-      principles:
-        - Helpfulness to the end user
-      llm:
-        provider: openai
-        model: gpt-4o-mini
-        api_key_env: OPENAI_API_KEY
-        temperature: 0.0
-        max_output_tokens: 512
-  temperatures: [0.0, 0.3]
-  variance_threshold: 0.15
-  uncertainty_threshold: 0.3
-  arbiter:
+  small_model:
+    provider: openai
+    model: gpt-4o-mini
+    api_key_env: OPENAI_API_KEY
+    max_output_tokens: 512
+  large_model:
     provider: openai
     model: gpt-4o
     api_key_env: OPENAI_API_KEY
-    temperature: 0.1
     max_output_tokens: 768
-  success_threshold: 0.7
-  retry_threshold: 0.6
-  aggregation_strategy: weighted_mean
+  active_judges:
+    process: true
+    helpfulness: true
+  variance_threshold: 0.15
+  uncertainty_threshold: 0.3
 
 storage:
   database_url: postgresql://localhost:5432/atlas

--- a/configs/examples/http_agent.yaml
+++ b/configs/examples/http_agent.yaml
@@ -30,20 +30,6 @@ agent:
     - output
 
 student:
-  prompts:
-    planner: |
-      {base_prompt}
-
-      You are the Atlas Student. Produce a step-by-step plan that solves the user's task.
-      Respond with JSON containing a "steps" array where each step specifies id, description, dependencies, and any tool metadata.
-  executor: |
-      {base_prompt}
-
-      Follow the plan step exactly. Use provided context and produce detailed operations.
-  synthesizer: |
-      {base_prompt}
-
-      Combine the outcomes of every step into a final, user-ready answer.
   max_plan_tokens: 2048
   max_step_tokens: 2048
   max_synthesis_tokens: 2048

--- a/configs/examples/openai_agent.yaml
+++ b/configs/examples/openai_agent.yaml
@@ -13,19 +13,6 @@ agent:
   response_format: null
 
 student:
-  prompts:
-    planner: |
-      {base_prompt}
-
-      Produce a step-by-step execution plan as JSON.
-    executor: |
-      {base_prompt}
-
-      Execute the current step and explain what you did.
-    synthesizer: |
-      {base_prompt}
-
-      Use all step outputs to craft the final response.
   max_plan_tokens: 2048
   max_step_tokens: 2048
   max_synthesis_tokens: 2048

--- a/configs/examples/openai_agent.yaml
+++ b/configs/examples/openai_agent.yaml
@@ -47,41 +47,21 @@ orchestration:
   emit_intermediate_steps: true
 
 rim:
-  judges:
-    - identifier: process
-      kind: process
-      weight: 0.5
-      principles:
-        - Logical reasoning
-      llm:
-        provider: openai
-        model: gpt-4o-mini
-        api_key_env: OPENAI_API_KEY
-        temperature: 0.0
-        max_output_tokens: 512
-    - identifier: helpfulness
-      kind: helpfulness
-      weight: 0.5
-      principles:
-        - User impact
-      llm:
-        provider: openai
-        model: gpt-4o-mini
-        api_key_env: OPENAI_API_KEY
-        temperature: 0.0
-        max_output_tokens: 512
-  temperatures: [0.0, 0.3]
-  variance_threshold: 0.15
-  uncertainty_threshold: 0.3
-  arbiter:
+  small_model:
+    provider: openai
+    model: gpt-4o-mini
+    api_key_env: OPENAI_API_KEY
+    max_output_tokens: 512
+  large_model:
     provider: openai
     model: gpt-4o
     api_key_env: OPENAI_API_KEY
-    temperature: 0.1
     max_output_tokens: 768
-  success_threshold: 0.7
-  retry_threshold: 0.6
-  aggregation_strategy: weighted_mean
+  active_judges:
+    process: true
+    helpfulness: true
+  variance_threshold: 0.15
+  uncertainty_threshold: 0.3
 
 storage:
   database_url: postgresql://localhost:5432/atlas

--- a/configs/examples/python_agent.yaml
+++ b/configs/examples/python_agent.yaml
@@ -10,19 +10,6 @@ agent:
   allow_generator: false
 
 student:
-  prompts:
-    planner: |
-      {base_prompt}
-
-      Break the task into a minimal sequence of dependent steps expressed as JSON.
-    executor: |
-      {base_prompt}
-
-      Execute the current step carefully, calling Python helpers when needed.
-    synthesizer: |
-      {base_prompt}
-
-      Summarize every completed step and deliver the final answer.
   max_plan_tokens: 2048
   max_step_tokens: 2048
   max_synthesis_tokens: 2048

--- a/configs/examples/python_agent.yaml
+++ b/configs/examples/python_agent.yaml
@@ -44,41 +44,21 @@ orchestration:
   emit_intermediate_steps: true
 
 rim:
-  judges:
-    - identifier: process
-      kind: process
-      weight: 0.6
-      principles:
-        - Followed instructions precisely
-      llm:
-        provider: openai
-        model: gpt-4o-mini
-        api_key_env: OPENAI_API_KEY
-        temperature: 0.0
-        max_output_tokens: 512
-    - identifier: helpfulness
-      kind: helpfulness
-      weight: 0.4
-      principles:
-        - Improved task completion likelihood
-      llm:
-        provider: openai
-        model: gpt-4o-mini
-        api_key_env: OPENAI_API_KEY
-        temperature: 0.0
-        max_output_tokens: 512
-  temperatures: [0.0, 0.3]
-  variance_threshold: 0.15
-  uncertainty_threshold: 0.3
-  arbiter:
+  small_model:
+    provider: openai
+    model: gpt-4o-mini
+    api_key_env: OPENAI_API_KEY
+    max_output_tokens: 512
+  large_model:
     provider: openai
     model: gpt-4o
     api_key_env: OPENAI_API_KEY
-    temperature: 0.1
     max_output_tokens: 768
-  success_threshold: 0.75
-  retry_threshold: 0.65
-  aggregation_strategy: weighted_mean
+  active_judges:
+    process: true
+    helpfulness: true
+  variance_threshold: 0.15
+  uncertainty_threshold: 0.3
 
 storage:
   database_url: postgresql://localhost:5432/atlas

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -2,7 +2,9 @@ import asyncio
 
 import pytest
 
-from atlas.config.models import AdapterConfig, AdapterType, JudgeConfig, JudgeKind, LLMParameters, OrchestrationConfig, RIMConfig, StudentConfig, StudentPrompts, TeacherConfig
+pytest.importorskip("langchain_core")
+
+from atlas.config.models import AdapterConfig, AdapterType, LLMParameters, OrchestrationConfig, RIMConfig, StudentConfig, StudentPrompts, TeacherConfig
 from atlas.transition.rewriter import RewrittenStudentPrompts, RewrittenTeacherPrompts
 from atlas.types import Plan, Result, StepResult
 
@@ -52,14 +54,12 @@ def test_core_run_assembles_pipeline(monkeypatch):
                 "teacher": TeacherConfig(llm=LLMParameters(model="model")),
                 "orchestration": OrchestrationConfig(max_retries=0, step_timeout_seconds=10, rim_guidance_tag="tag", emit_intermediate_steps=True),
                 "rim": RIMConfig(
-                    judges=[JudgeConfig(identifier="process", kind=JudgeKind.PROCESS, llm=LLMParameters(model="stub"))],
-                    temperatures=[0.0],
+                    small_model=LLMParameters(model="stub"),
+                    large_model=LLMParameters(model="arbiter"),
+                    active_judges={"process": True},
                     variance_threshold=1.0,
                     uncertainty_threshold=1.0,
-                    arbiter=LLMParameters(model="arbiter"),
-                    success_threshold=0.7,
-                    retry_threshold=0.6,
-                    aggregation_strategy="weighted_mean",
+                    parallel_workers=1,
                 ),
                 "storage": None,
                 "prompt_rewrite": None,

--- a/tests/integration/test_orchestrator.py
+++ b/tests/integration/test_orchestrator.py
@@ -3,7 +3,7 @@ import pytest
 pytest.importorskip("langchain_core")
 
 from langchain_core.messages import AIMessage, ToolMessage
-from atlas.config.models import OrchestrationConfig, RIMConfig, JudgeConfig, JudgeKind, LLMParameters
+from atlas.config.models import OrchestrationConfig, RIMConfig, LLMParameters
 from atlas.orchestration.execution_context import ExecutionContext
 from atlas.orchestration.orchestrator import Orchestrator
 from atlas.data_models.intermediate_step import IntermediateStepType
@@ -82,16 +82,12 @@ class FakeEvaluator:
 def build_orchestrator():
     orchestration_config = OrchestrationConfig(max_retries=1, step_timeout_seconds=900, rim_guidance_tag="tag", emit_intermediate_steps=True)
     rim_config = RIMConfig(
-        judges=[
-            JudgeConfig(identifier="process", kind=JudgeKind.PROCESS, llm=LLMParameters(model="stub"))
-        ],
-        temperatures=[0.0],
+        small_model=LLMParameters(model="stub"),
+        large_model=LLMParameters(model="arbiter"),
+        active_judges={"process": True, "helpfulness": True},
         variance_threshold=1.0,
         uncertainty_threshold=1.0,
-        arbiter=LLMParameters(model="arbiter"),
-        success_threshold=0.7,
-        retry_threshold=0.6,
-        aggregation_strategy="weighted_mean",
+        parallel_workers=2,
     )
     return Orchestrator(
         teacher=FakeTeacher(),


### PR DESCRIPTION
## Summary
- remove per-judge configuration and wire Atlas RIM to the canonical reward prompts
- harden process/helpfulness prompts for production and align evaluator with tier-1/arbiter flow
- update examples and tests to rely on built-in RIM defaults

Fixes #6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Parallel step execution by plan levels.
  - Model-centric RIM setup with active judges (process/helpfulness) and parallel_workers.
  - Optional student/teacher prompts plus prompt guidance.
  - Standardized judge outputs with clearer scoring.
  - Expanded storage settings (min/max connections, statement timeout).

- Refactor
  - Simplified evaluation and aggregation; removed legacy judge types/thresholds.
  - Judges/evaluator now use unified clients.
  - Persona-based, parallel prompt rewriting for students/teachers.

- Documentation
  - Example configs updated to the new RIM structure and storage options.

- Tests
  - Integration/unit tests updated for new orchestration, evaluator, and rewrite flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->