### PR TITLE
Add runtime JSONL exporter and reasoning telemetry capture

### DIFF
--- a/atlas/config/models.py
+++ b/atlas/config/models.py
@@ -125,6 +125,8 @@ class LLMParameters(BaseModel):
     timeout_seconds: float = Field(default=60.0, ge=0.0)
     retry: RetryPolicy = Field(default_factory=RetryPolicy)
     additional_headers: Dict[str, str] = Field(default_factory=dict)
+    supports_reasoning: bool = Field(default=False)
+    reasoning_effort: Literal["low", "medium", "high"] | None = None
 
 class OpenAIAdapterConfig(AdapterConfig):
     """Adapter that proxies OpenAI compatible chat completions."""

--- a/atlas/export/__init__.py
+++ b/atlas/export/__init__.py
@@ -1,0 +1,6 @@
+"""Atlas runtime exporters."""
+
+from .jsonl import ExportRequest, ExportSummary, export_sessions, export_sessions_sync
+
+__all__ = ["ExportRequest", "ExportSummary", "export_sessions", "export_sessions_sync"]
+

--- a/atlas/export/cli.py
+++ b/atlas/export/cli.py
@@ -1,0 +1,93 @@
+"""Command line entry point for the Atlas JSONL exporter."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from typing import Sequence
+
+from atlas.export.jsonl import ExportRequest, export_sessions_sync
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="atlas.export",
+        description="Export persisted Atlas runtime sessions to JSONL.",
+    )
+    parser.add_argument("--database-url", required=True, help="PostgreSQL connection URL.")
+    parser.add_argument("--output", required=True, help="Destination JSONL file.")
+    parser.add_argument(
+        "--session-id",
+        action="append",
+        dest="session_ids",
+        type=int,
+        help="Specific session ID to export. Repeat for multiple sessions.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum number of sessions to export when no explicit IDs are provided (default: 50).",
+    )
+    parser.add_argument(
+        "--offset",
+        type=int,
+        default=0,
+        help="Offset applied when fetching recent sessions without explicit IDs.",
+    )
+    parser.add_argument(
+        "--status",
+        action="append",
+        dest="statuses",
+        help="Filter sessions by status. Repeat to allow multiple statuses.",
+    )
+    parser.add_argument(
+        "--trajectory-event-limit",
+        type=int,
+        default=200,
+        help="Maximum number of trajectory events to include per session.",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress informational logs and only emit warnings/errors.",
+    )
+    return parser
+
+
+def configure_logging(quiet: bool) -> None:
+    level = logging.WARNING if quiet else logging.INFO
+    logging.basicConfig(level=level, format="%(levelname)s %(message)s")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    configure_logging(args.quiet)
+
+    request = ExportRequest(
+        database_url=args.database_url,
+        output_path=Path(args.output).expanduser().resolve(),
+        session_ids=args.session_ids,
+        limit=args.limit,
+        offset=args.offset,
+        status_filters=args.statuses,
+        trajectory_event_limit=args.trajectory_event_limit,
+    )
+
+    summary = export_sessions_sync(request)
+    if summary.sessions == 0:
+        logging.warning("No sessions were exported. Verify your filters and database contents.")
+        return 1
+    logging.info(
+        "Completed export of %s sessions (%s steps).",
+        summary.sessions,
+        summary.steps,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/atlas/export/jsonl.py
+++ b/atlas/export/jsonl.py
@@ -1,0 +1,286 @@
+"""Utilities for exporting persisted runtime sessions as JSONL traces."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+from pydantic import ValidationError
+
+from atlas.config.models import StorageConfig
+from atlas.storage.database import Database
+from atlas.types import Plan
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class ExportRequest:
+    """Parameters controlling the export process."""
+
+    database_url: str
+    output_path: Path
+    session_ids: Sequence[int] | None = None
+    limit: int | None = None
+    offset: int = 0
+    status_filters: Sequence[str] | None = None
+    trajectory_event_limit: int = 200
+
+
+@dataclass(slots=True)
+class ExportSummary:
+    sessions: int = 0
+    steps: int = 0
+
+    def merge(self, other: "ExportSummary") -> None:
+        self.sessions += other.sessions
+        self.steps += other.steps
+
+
+async def export_sessions(request: ExportRequest) -> ExportSummary:
+    """Export matching sessions to newline-delimited JSON."""
+
+    database = Database(StorageConfig(database_url=request.database_url))
+    await database.connect()
+    summary = ExportSummary()
+    try:
+        session_ids = await _resolve_session_ids(database, request)
+        if not session_ids:
+            logger.info("No sessions matched the provided filters.")
+            return summary
+
+        output_path = request.output_path
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        with output_path.open("w", encoding="utf-8") as handle:
+            for session_id in session_ids:
+                record = await _build_session_record(database, session_id, request.trajectory_event_limit)
+                if record is None:
+                    logger.warning("Skipping session %s because it could not be retrieved.", session_id)
+                    continue
+                handle.write(json.dumps(record, ensure_ascii=False))
+                handle.write("\n")
+                summary.sessions += 1
+                summary.steps += len(record.get("steps") or [])
+        logger.info(
+            "Exported %s sessions (%s steps) to %s",
+            summary.sessions,
+            summary.steps,
+            output_path,
+        )
+        return summary
+    finally:
+        await database.disconnect()
+
+
+def export_sessions_sync(request: ExportRequest) -> ExportSummary:
+    """Synchronous helper for CLI usage."""
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(export_sessions(request))
+    raise RuntimeError("export_sessions_sync cannot run within an existing event loop")
+
+
+async def _resolve_session_ids(database: Database, request: ExportRequest) -> List[int]:
+    if request.session_ids:
+        return list(dict.fromkeys(int(sid) for sid in request.session_ids))
+
+    limit = request.limit or 50
+    rows = await database.fetch_sessions(limit=limit, offset=request.offset)
+    filtered: List[int] = []
+    statuses = {status.lower() for status in request.status_filters or []}
+    for row in rows:
+        if statuses and str(row.get("status", "")).lower() not in statuses:
+            continue
+        filtered.append(int(row["id"]))
+    return filtered
+
+
+async def _build_session_record(
+    database: Database,
+    session_id: int,
+    trajectory_event_limit: int,
+) -> Optional[Dict[str, Any]]:
+    session = await database.fetch_session(session_id)
+    if session is None:
+        return None
+
+    plan_model = _parse_plan(session.get("plan"))
+    plan_index = _index_plan(plan_model)
+
+    steps_raw = await database.fetch_session_steps(session_id)
+    events_raw = await database.fetch_trajectory_events(session_id, limit=trajectory_event_limit)
+
+    session_metadata = _coerce_dict(session.get("metadata"))
+    session_metadata = dict(session_metadata)
+    session_metadata.setdefault("status", session.get("status"))
+    session_metadata.setdefault("created_at", _iso_or_none(session.get("created_at")))
+    session_metadata.setdefault("completed_at", _iso_or_none(session.get("completed_at")))
+
+    steps = [_build_step_record(row, plan_index) for row in steps_raw]
+
+    record: Dict[str, Any] = {
+        "session_id": session_id,
+        "task": session.get("task") or "",
+        "final_answer": session.get("final_answer") or "",
+        "plan": plan_model.model_dump() if plan_model else _plan_payload(session.get("plan")),
+        "steps": steps,
+        "session_metadata": session_metadata,
+    }
+
+    if events_raw:
+        record["trajectory_events"] = [_coerce_dict(row.get("event")) for row in events_raw]
+
+    return record
+
+
+def _parse_plan(raw_plan: Any) -> Plan | None:
+    if raw_plan is None:
+        return None
+    if isinstance(raw_plan, str):
+        try:
+            raw_plan = json.loads(raw_plan)
+        except json.JSONDecodeError:
+            return None
+    try:
+        return Plan.model_validate(raw_plan)
+    except ValidationError:
+        return None
+
+
+def _plan_payload(raw_plan: Any) -> Dict[str, Any]:
+    if raw_plan is None:
+        return {}
+    if isinstance(raw_plan, dict):
+        return raw_plan
+    if isinstance(raw_plan, str):
+        try:
+            parsed = json.loads(raw_plan)
+        except json.JSONDecodeError:
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+def _index_plan(plan: Plan | None) -> Dict[int, Dict[str, Any]]:
+    if plan is None:
+        return {}
+    index: Dict[int, Dict[str, Any]] = {}
+    for step in plan.steps:
+        index[step.id] = {
+            "description": step.description,
+            "tool": step.tool,
+            "tool_params": step.tool_params or {},
+        }
+    return index
+
+
+def _build_step_record(row: Dict[str, Any], plan_index: Dict[int, Dict[str, Any]]) -> Dict[str, Any]:
+    step_id = row.get("step_id", 0)
+    plan_entry = plan_index.get(step_id, {})
+    evaluation = _coerce_dict(row.get("evaluation"))
+    reward = _coerce_reward(evaluation.get("reward"))
+    validation = _coerce_dict(evaluation.get("validation"))
+    metadata = _coerce_dict(row.get("metadata"))
+    if row.get("attempt_details"):
+        metadata.setdefault("attempt_details", row["attempt_details"])
+
+    return {
+        "step_id": step_id,
+        "description": plan_entry.get("description", ""),
+        "trace": row.get("trace") or "",
+        "output": row.get("output") or "",
+        "reward": reward,
+        "tool": plan_entry.get("tool"),
+        "tool_params": plan_entry.get("tool_params") or {},
+        "context": {},
+        "validation": validation,
+        "attempts": row.get("attempts") or 0,
+        "guidance": row.get("guidance_notes") or [],
+        "metadata": metadata,
+    }
+
+
+def _coerce_reward(raw_reward: Any) -> Dict[str, Any]:
+    payload = _coerce_dict(raw_reward)
+    judges: List[Dict[str, Any]] = []
+    for entry in payload.get("judges", []) or []:
+        entry_dict = entry if isinstance(entry, dict) else _coerce_dict(entry)
+        samples: List[Dict[str, Any]] = []
+        for sample in entry_dict.get("samples", []) or []:
+            sample_dict = sample if isinstance(sample, dict) else _coerce_dict(sample)
+            samples.append(
+                {
+                    "score": _coerce_float(sample_dict, "score"),
+                    "rationale": _coerce_str(sample_dict, "rationale"),
+                    "principles": sample_dict.get("principles") or [],
+                    "uncertainty": sample_dict.get("uncertainty"),
+                    "temperature": sample_dict.get("temperature"),
+                }
+            )
+        judges.append(
+            {
+                "identifier": entry_dict.get("identifier", ""),
+                "score": _coerce_float(entry_dict, "score"),
+                "rationale": _coerce_str(entry_dict, "rationale"),
+                "principles": entry_dict.get("principles") or [],
+                "samples": samples,
+                "escalated": bool(entry_dict.get("escalated", False)),
+                "escalation_reason": entry_dict.get("escalation_reason"),
+            }
+        )
+    return {
+        "score": _coerce_float(payload, "score"),
+        "rationale": payload.get("rationale"),
+        "judges": judges,
+        "raw": payload if payload else {},
+    }
+
+
+def _coerce_dict(value: Any) -> Dict[str, Any]:
+    if value is None:
+        return {}
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        if isinstance(parsed, dict):
+            return parsed
+    return {}
+
+
+def _coerce_str(source: Any, key: str) -> str:
+    if isinstance(source, dict):
+        value = source.get(key)
+    else:
+        value = None
+    return str(value) if value is not None else ""
+
+
+def _coerce_float(source: Any, key: str) -> float:
+    if isinstance(source, dict):
+        value = source.get(key)
+    else:
+        value = source
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _iso_or_none(value: Any) -> Optional[str]:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, str):
+        return value
+    return None

--- a/atlas/orchestration/orchestrator.py
+++ b/atlas/orchestration/orchestrator.py
@@ -79,6 +79,7 @@ class Orchestrator:
                         "output": result.output,
                         "trace": result.trace,
                         "evaluation": evaluation,
+                        "metadata": result.metadata,
                         "attempts": attempts,
                     }
                 )
@@ -89,6 +90,7 @@ class Orchestrator:
                         output=result.output,
                         evaluation=evaluation,
                         attempts=attempts,
+                        metadata=result.metadata,
                     )
                 )
             else:
@@ -134,6 +136,7 @@ class Orchestrator:
                             "output": result.output,
                             "trace": result.trace,
                             "evaluation": evaluation,
+                            "metadata": result.metadata,
                             "attempts": attempts,
                         }
                     )
@@ -144,6 +147,7 @@ class Orchestrator:
                             output=result.output,
                             evaluation=evaluation,
                             attempts=attempts,
+                            metadata=result.metadata,
                         )
                     )
                 if captured_exception is not None:
@@ -233,6 +237,7 @@ class Orchestrator:
                             "trace": student_result.trace,
                             "output": student_result.output,
                             "evaluation": evaluation,
+                            "metadata": student_result.metadata,
                         }
                     ),
                 )

--- a/atlas/reward/judge.py
+++ b/atlas/reward/judge.py
@@ -33,6 +33,7 @@ class JudgeSample:
     principles: List[Dict[str, Any]]
     uncertainty: float
     temperature: float
+    reasoning: Dict[str, Any] | None = None
 
 
 @dataclass
@@ -46,6 +47,7 @@ class JudgeOutcome:
     samples: List[JudgeSample]
     escalated: bool
     escalation_reason: str | None
+    reasoning: Dict[str, Any] | None = None
 
 
 class Judge:
@@ -92,6 +94,7 @@ class Judge:
             principles=parsed_principles,
             uncertainty=float(uncertainty),
             temperature=temperature,
+            reasoning=response.reasoning or payload.get("reasoning"),
         )
 
     async def ajudge(self, context: JudgeContext) -> JudgeOutcome:

--- a/atlas/storage/database.py
+++ b/atlas/storage/database.py
@@ -68,18 +68,21 @@ class Database:
     async def log_step_result(self, session_id: int, result: StepResult) -> None:
         pool = self._require_pool()
         serialized_evaluation = self._serialize_json(result.evaluation)
+        serialized_metadata = self._serialize_json(result.metadata) if result.metadata else None
         async with pool.acquire() as connection:
             await connection.execute(
-                "INSERT INTO step_results(session_id, step_id, trace, output, evaluation, attempts)"
-                " VALUES ($1, $2, $3, $4, $5, $6)"
+                "INSERT INTO step_results(session_id, step_id, trace, output, evaluation, attempts, metadata)"
+                " VALUES ($1, $2, $3, $4, $5, $6, $7)"
                 " ON CONFLICT (session_id, step_id) DO UPDATE SET"
-                " trace = EXCLUDED.trace, output = EXCLUDED.output, evaluation = EXCLUDED.evaluation, attempts = EXCLUDED.attempts",
+                " trace = EXCLUDED.trace, output = EXCLUDED.output, evaluation = EXCLUDED.evaluation,"
+                " attempts = EXCLUDED.attempts, metadata = EXCLUDED.metadata",
                 session_id,
                 result.step_id,
                 result.trace,
                 result.output,
                 serialized_evaluation,
                 result.attempts,
+                serialized_metadata,
             )
 
     async def log_step_attempts(
@@ -173,7 +176,7 @@ class Database:
         pool = self._require_pool()
         async with pool.acquire() as connection:
             step_rows = await connection.fetch(
-                "SELECT step_id, trace, output, evaluation, attempts"
+                "SELECT step_id, trace, output, evaluation, attempts, metadata"
                 " FROM step_results WHERE session_id = $1 ORDER BY step_id",
                 session_id,
             )
@@ -205,6 +208,7 @@ class Database:
                     "output": row["output"],
                     "evaluation": row["evaluation"],
                     "attempts": row["attempts"],
+                    "metadata": row["metadata"],
                     "attempt_details": attempts_by_step.get(step_id, []),
                     "guidance_notes": guidance_by_step.get(step_id, []),
                 }

--- a/atlas/storage/schema.sql
+++ b/atlas/storage/schema.sql
@@ -20,6 +20,7 @@ CREATE TABLE IF NOT EXISTS step_results (
     output TEXT,
     evaluation JSONB,
     attempts INTEGER,
+    metadata JSONB,
     PRIMARY KEY (session_id, step_id)
 );
 

--- a/atlas/types.py
+++ b/atlas/types.py
@@ -20,6 +20,7 @@ class StepResult(BaseModel):
     output: str
     evaluation: dict
     attempts: int = 1
+    metadata: dict = Field(default_factory=dict)
 
 
 class Result(BaseModel):

--- a/atlas/utils/llm_client.py
+++ b/atlas/utils/llm_client.py
@@ -4,19 +4,18 @@ from __future__ import annotations
 
 import json
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from typing import Dict
 from typing import List
 from typing import Sequence
 
 try:
-    from litellm import acompletion
-    from litellm import completion
+    import litellm
     _LITELLM_ERROR = None
+    litellm.drop_params = True
 except ModuleNotFoundError as exc:
-    acompletion = None
-    completion = None
+    litellm = None
     _LITELLM_ERROR = exc
 
 from atlas.config.models import LLMParameters
@@ -26,6 +25,7 @@ from atlas.config.models import LLMParameters
 class LLMResponse:
     content: str
     raw: Any
+    reasoning: Dict[str, Any] = field(default_factory=dict)
 
 
 class LLMClient:
@@ -40,8 +40,9 @@ class LLMClient:
     ) -> LLMResponse:
         self._ensure_client()
         kwargs = self._prepare_kwargs(messages, response_format, overrides)
-        result = await acompletion(**kwargs)
-        return LLMResponse(content=self._extract_content(result), raw=result)
+        result = await litellm.acompletion(**kwargs)
+        content, reasoning = self._extract_content(result)
+        return LLMResponse(content=content, reasoning=reasoning, raw=result)
 
     def complete(
         self,
@@ -51,8 +52,9 @@ class LLMClient:
     ) -> LLMResponse:
         self._ensure_client()
         kwargs = self._prepare_kwargs(messages, response_format, overrides)
-        result = completion(**kwargs)
-        return LLMResponse(content=self._extract_content(result), raw=result)
+        result = litellm.completion(**kwargs)
+        content, reasoning = self._extract_content(result)
+        return LLMResponse(content=content, reasoning=reasoning, raw=result)
 
     def _prepare_kwargs(
         self,
@@ -64,55 +66,62 @@ class LLMClient:
         api_key = os.getenv(params.api_key_env)
         if not api_key:
             raise RuntimeError(f"Environment variable '{params.api_key_env}' is not set")
-        kwargs: Dict[str, Any] = {
-            "model": params.model,
-            "messages": list(messages),
-            "api_key": api_key,
-            "temperature": params.temperature,
-            "timeout": params.timeout_seconds,
-        }
+        overrides = overrides or {}
+        kwargs: Dict[str, Any] = {"model": params.model, "messages": list(messages), "api_key": api_key}
         if params.api_base:
             kwargs["api_base"] = params.api_base
         if params.organization:
             kwargs["organization"] = params.organization
+        if params.temperature is not None:
+            kwargs["temperature"] = params.temperature
         if params.top_p is not None:
             kwargs["top_p"] = params.top_p
         if params.max_output_tokens is not None:
             kwargs["max_tokens"] = params.max_output_tokens
-        if params.additional_headers:
-            kwargs["extra_headers"] = params.additional_headers
+        kwargs["timeout"] = params.timeout_seconds
         if response_format:
             kwargs["response_format"] = response_format
-        if overrides:
-            for key, value in overrides.items():
-                if value is not None:
-                    kwargs[key] = value
-        if "gpt-5" in params.model.lower():
-            headers = dict(kwargs.get("extra_headers") or {})
-            headers.setdefault("OpenAI-Beta", "reasoning=1")
-            kwargs["extra_headers"] = headers
-            kwargs["temperature"] = 1.0
-            extra_body = dict(kwargs.get("extra_body") or {})
-            extra_body.setdefault("reasoning_effort", "medium")
+
+        extra_headers = dict(params.additional_headers)
+        override_headers = overrides.pop("extra_headers", None)
+        if override_headers:
+            extra_headers.update(override_headers)
+
+        extra_body = dict(overrides.pop("extra_body", {}) or {})
+        if params.supports_reasoning and params.reasoning_effort:
+            extra_body.setdefault("reasoning_effort", params.reasoning_effort)
+
+        if extra_headers:
+            kwargs["extra_headers"] = extra_headers
+        if extra_body:
             kwargs["extra_body"] = extra_body
+
+        for key, value in overrides.items():
+            if value is not None:
+                kwargs[key] = value
         return kwargs
 
     def _ensure_client(self) -> None:
-        if acompletion is None or completion is None:
+        if litellm is None:
             raise RuntimeError("litellm is required for LLMClient operations") from _LITELLM_ERROR
 
 
-    def _extract_content(self, response: Any) -> str:
+    def _extract_content(self, response: Any) -> tuple[str, Dict[str, Any]]:
         try:
             choice = response["choices"][0]
             message = choice["message"]
             content = message.get("content")
             if content is None and "tool_calls" in message:
-                return json.dumps(message["tool_calls"])
+                return json.dumps(message["tool_calls"]), {}
+            reasoning_payload: Dict[str, Any] = {}
+            for key in ("reasoning_content", "thinking", "thinking_blocks"):
+                value = message.get(key)
+                if value:
+                    reasoning_payload[key] = value
             if content is None or str(content).strip() == "":
                 import logging
                 logger = logging.getLogger(__name__)
                 logger.warning(f"LLM returned empty content. Full response: {response}")
-            return str(content or "")
+            return str(content or ""), reasoning_payload
         except (KeyError, IndexError, TypeError) as exc:
             raise RuntimeError(f"Unexpected response format from LLM client. Response: {response}") from exc

--- a/docs/telemetry_overview.md
+++ b/docs/telemetry_overview.md
@@ -1,0 +1,63 @@
+# Telemetry & Runtime Data Flow
+
+Atlas SDK keeps telemetry intentionally lightweight so existing agent builders can plug the runtime into their production
+systems without standing up new tracing infrastructure. This note summarises the current pipeline, the data contract with
+the Atlas core repository, and how to export traces for offline training.
+
+---
+
+## Runtime Event Stream
+
+- Every `atlas.core.run` invocation initialises an `ExecutionContext`.  
+- Components (student, teacher, evaluator, orchestration helpers) push `IntermediateStepPayload` objects through the
+  context’s `IntermediateStepManager`, creating a lightweight in-process event stream.  
+- The console renderer and Postgres persistence layer are the only subscribers today; there is no LangChain callback or
+  OpenTelemetry dependency by default.
+
+This design keeps local development fast—no background services or network calls—while still capturing the complete
+workflow history when persistence is enabled.
+
+---
+
+## Data Contract with Atlas Core
+
+The persisted data must match the schema expected by the training stack in
+[Arc-Computer/ATLAS](https://github.com/Arc-Computer/ATLAS) (`atlas_core/runtime/schema.py`). The SDK currently records:
+
+- **Session envelope** – task string, final answer, plan JSON, and user-supplied metadata.
+- **Step traces** – description, executor trace, student output, validation verdicts, retry guidance, attempt counts,
+  and the full reward breakdown (`score`, per-judge details, tier samples). Reasoning blocks captured from the
+  underlying LLM are attached under `metadata`.
+- **Trajectory events** – serialized `IntermediateStepPayload` items describing workflow/tool/LLM boundaries for replay
+  or advanced analytics.
+
+Running `atlas.export --database-url ... --output traces.jsonl` materialises the JSONL format consumed by
+`trainers/runtime_dataset.py` in the core repo. Loading the file via `load_runtime_traces("traces.jsonl")` returns
+`AtlasSessionTrace` objects without additional adapters.
+
+---
+
+## Developer Workflow
+
+1. Configure PostgreSQL persistence in your Atlas config (`storage.database_url`).
+2. Execute workloads with `atlas.core.run(...)`; telemetry remains in-process unless persistence is enabled.
+3. Invoke `atlas.export` to produce training-ready JSONL.
+4. Feed the export into Atlas core utilities (`load_runtime_traces`, `flatten_traces_for_training`, etc.).
+
+There are no mandatory external tracing systems—developers can keep using their existing agent infrastructure and opt
+into richer telemetry later if needed.
+
+---
+
+## Extensibility Guidelines
+
+If you need deeper observability (e.g., LangChain callbacks or OpenTelemetry exporters):
+
+- Prefer building on top of `IntermediateStepManager` to avoid schema drift.
+- Preserve the `AtlasSessionTrace`/`AtlasStepTrace` fields so exported datasets remain compatible with the core repo.
+- Document any additional metadata you surface so consumers can feature-gate on it.
+
+By default, the SDK prioritises simplicity and data fidelity over heavy telemetry instrumentation. This keeps the
+onboarding path short for teams that already operate agents in production while ensuring the exported traces slot
+directly into the Atlas training stack.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,12 @@ dependencies = [
     "httpx>=0.25.0",
     "langchain-core>=0.1.52",
     "langgraph>=0.2.30",
-    "litellm>=1.36.0",
+    "litellm>=1.77.7",
     "pydantic>=2.5.0",
 ]
+
+[project.scripts]
+atlas.export = "atlas.export.cli:main"
 
 [project.optional-dependencies]
 dev = [

--- a/tests/unit/export/test_jsonl.py
+++ b/tests/unit/export/test_jsonl.py
@@ -1,0 +1,172 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from atlas.export.jsonl import ExportRequest, export_sessions_sync
+
+
+class FakeDatabase:
+    def __init__(self, _config):
+        self.connected = False
+
+    async def connect(self):
+        self.connected = True
+
+    async def disconnect(self):
+        self.connected = False
+
+    async def fetch_sessions(self, limit: int = 50, offset: int = 0):
+        return [
+            {
+                "id": 1,
+                "task": "demo task",
+                "status": "succeeded",
+                "metadata": {"dataset": "demo"},
+                "created_at": None,
+                "completed_at": None,
+            }
+        ]
+
+    async def fetch_session(self, session_id: int):
+        assert session_id == 1
+        return {
+            "id": 1,
+            "task": "demo task",
+            "status": "succeeded",
+            "metadata": {"dataset": "demo"},
+            "final_answer": "done",
+            "plan": {
+                "steps": [
+                    {
+                        "id": 1,
+                        "description": "collect data",
+                        "tool": "search",
+                        "tool_params": {"query": "atlas"},
+                        "depends_on": [],
+                    }
+                ]
+            },
+            "created_at": None,
+            "completed_at": None,
+        }
+
+    async def fetch_session_steps(self, session_id: int):
+        assert session_id == 1
+        return [
+            {
+                "step_id": 1,
+                "trace": "AI: finished",
+                "output": "atlas summary",
+                "evaluation": {
+                    "validation": {"valid": True, "rationale": "looks good"},
+                    "reward": {
+                        "score": 0.92,
+                        "judges": [
+                            {
+                                "identifier": "process",
+                                "score": 0.9,
+                                "rationale": "solid reasoning",
+                                "principles": [],
+                                "samples": [
+                                    {
+                                        "score": 0.9,
+                                        "rationale": "good",
+                                        "principles": [],
+                                        "uncertainty": 0.1,
+                                        "temperature": 0.2,
+                                    }
+                                ],
+                                "escalated": False,
+                                "escalation_reason": None,
+                            }
+                        ],
+                    },
+                },
+                "attempts": 1,
+                "metadata": {
+                    "reasoning": [
+                        {
+                            "message_index": 2,
+                            "role": "ai",
+                            "payload": {"reasoning_content": [{"type": "thought", "text": "analysis"}]},
+                        }
+                    ]
+                },
+                "guidance_notes": ["cite sources"],
+                "attempt_details": [{"attempt": 1, "evaluation": {"reward": {"score": 0.9}}}],
+            }
+        ]
+
+    async def fetch_trajectory_events(self, session_id: int, limit: int = 200):
+        assert session_id == 1
+        assert limit == 200
+        return [
+            {
+                "id": 99,
+                "event": {"type": "TASK_START", "name": "step_1"},
+                "created_at": None,
+            }
+        ]
+
+
+class EmptyDatabase(FakeDatabase):
+    async def fetch_sessions(self, limit: int = 50, offset: int = 0):
+        return []
+
+    async def fetch_session(self, session_id: int):
+        return None
+
+    async def fetch_session_steps(self, session_id: int):
+        return []
+
+    async def fetch_trajectory_events(self, session_id: int, limit: int = 200):
+        return []
+
+
+def test_exporter_writes_expected_jsonl(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr("atlas.export.jsonl.Database", FakeDatabase)
+    output_path = tmp_path / "traces.jsonl"
+
+    request = ExportRequest(
+        database_url="postgresql://stub",
+        output_path=output_path,
+        limit=1,
+    )
+
+    summary = export_sessions_sync(request)
+    assert summary.sessions == 1
+    assert summary.steps == 1
+    payloads = [json.loads(line) for line in output_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert len(payloads) == 1
+    record = payloads[0]
+    assert record["task"] == "demo task"
+    assert record["final_answer"] == "done"
+    assert isinstance(record["plan"], dict) and record["plan"]["steps"][0]["description"] == "collect data"
+    assert record["session_metadata"]["status"] == "succeeded"
+    assert record["trajectory_events"][0]["type"] == "TASK_START"
+    step = record["steps"][0]
+    assert step["description"] == "collect data"
+    assert step["reward"]["score"] == pytest.approx(0.92)
+    assert step["reward"]["judges"][0]["identifier"] == "process"
+    assert step["validation"]["valid"] is True
+    assert step["guidance"] == ["cite sources"]
+    assert step["metadata"]["reasoning"][0]["payload"]["reasoning_content"][0]["text"] == "analysis"
+    assert step["metadata"]["attempt_details"][0]["attempt"] == 1
+
+
+def test_exporter_handles_empty_results(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr("atlas.export.jsonl.Database", EmptyDatabase)
+    output_path = tmp_path / "traces.jsonl"
+
+    request = ExportRequest(
+        database_url="postgresql://stub",
+        output_path=output_path,
+        limit=5,
+    )
+
+    summary = export_sessions_sync(request)
+    assert summary.sessions == 0
+    assert summary.steps == 0
+    assert not output_path.exists()
+

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -93,4 +93,6 @@ async def test_database_logs_plan_steps(monkeypatch):
     assert any("INSERT INTO step_attempts" in command[0] for command in commands)
     assert any("INSERT INTO guidance_notes" in command[0] for command in commands)
     assert any("INSERT INTO trajectory_events" in command[0] for command in commands)
+    step_insert = next(cmd for cmd in commands if "INSERT INTO step_results" in cmd[0])
+    assert "metadata" in step_insert[0].lower()
     await database.disconnect()


### PR DESCRIPTION
## Summary
- introduce atlas.export CLI for exporting Postgres sessions to JSONL aligned with Atlas core schema
- capture reasoning metadata across student, teacher, and reward flows and persist it in step results
- document lightweight telemetry contract and add tests covering exporter and reasoning propagation

## Testing
- PYTHONPATH=. PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_teacher.py tests/unit/test_evaluator.py tests/unit/test_student.py::test_student_extracts_reasoning_metadata tests/unit/export/test_jsonl.py