### PR TITLE
Fix telemetry end events and reasoning queue

### DIFF
--- a/atlas/roles/student.py
+++ b/atlas/roles/student.py
@@ -583,16 +583,16 @@ class Student:
                                 },
                             }
                         )
-            manager.push_intermediate_step(
-                IntermediateStepPayload(
-                    UUID=run_id,
-                    event_type=IntermediateStepType.LLM_END,
-                    name=node.name,
-                    data=StreamEventData(input=serialized_input, output=serialized_output),
-                    metadata=metadata,
+                manager.push_intermediate_step(
+                    IntermediateStepPayload(
+                        UUID=run_id,
+                        event_type=IntermediateStepType.LLM_END,
+                        name=node.name,
+                        data=StreamEventData(input=serialized_input, output=serialized_output),
+                        metadata=metadata,
+                    )
                 )
-            )
-            handled = True
+                handled = True
 
         elif event_type in {"on_chain_stream", "on_chat_model_stream"} and node.kind == "llm":
             chunk_payload = self._normalise_llm_chunk(run_id, serialized_chunk)

--- a/atlas/roles/teacher.py
+++ b/atlas/roles/teacher.py
@@ -49,6 +49,7 @@ class Teacher:
         except json.JSONDecodeError as exc:
             raise ValueError("Teacher plan review response was not valid JSON") from exc
         if not isinstance(payload, dict) or not payload.get("steps"):
+            self._consume_reasoning_metadata("teacher", "plan_review")
             return plan
         if response.reasoning:
             self._record_reasoning("teacher", "plan_review", response.reasoning)


### PR DESCRIPTION
 ## Summary
  - ensure student telemetry emits LLM_END events only for actual LLM nodes
  - clear the teacher reasoning queue when plan review returns the original plan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when AI response streams finish, ensuring end-of-response updates are consistently captured and reflected in the interface.
  - Ensured reasoning metadata is properly cleared even when a plan review is skipped, preventing stale information from affecting subsequent actions.
  - Minor stability and consistency improvements around processing of AI events and plan reviews, reducing edge-case hiccups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->