### PR TITLE
Add arc-atlas CLI alias and update export docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,11 @@ JSONL with the bundled exporter:
 # 1. Run tasks that log to Postgres (configure storage.database_url in your AtlasConfig)
 atlas.core.run(...)
 
-# 2. Export the captured sessions to JSONL
-atlas.export --database-url postgresql://localhost:5432/atlas --output traces.jsonl --limit 25
+# 2. Export the captured sessions to JSONL (use the unique CLI name to avoid PATH collisions)
+arc-atlas --database-url postgresql://localhost:5432/atlas --output traces.jsonl --limit 25
+
+# (Fall back to python -m if shell PATH ordering is unpredictable)
+python -m atlas.export.jsonl --database-url postgresql://localhost:5432/atlas --output traces.jsonl --limit 25
 
 # 3. Load the dataset inside the Atlas core repo
 from trainers.runtime_dataset import load_runtime_traces
@@ -180,13 +183,15 @@ For a deeper look at how these events map onto the Atlas training stack—and wh
 
 ## Exporting Runtime Sessions
 
-Use the `atlas.export` CLI to convert persisted PostgreSQL sessions into JSONL traces that match the core runtime schema.
+Use the `arc-atlas` CLI (or `python -m atlas.export.jsonl ...` if you prefer an explicit module invocation) to convert persisted PostgreSQL sessions into JSONL traces that match the core runtime schema.
 
 ```bash
-atlas.export \
+arc-atlas \
   --database-url postgresql://atlas:atlas@localhost:5432/atlas \
   --output traces.jsonl
 ```
+
+Compatibility aliases `atlas.export` and `atlas-export` remain available, but they may collide with other tools named `atlas` if those appear earlier in your `PATH`. `arc-atlas` and `python -m atlas.export.jsonl` are collision-proof.
 
 Key flags:
 

--- a/docs/examples/export_runtime_traces.md
+++ b/docs/examples/export_runtime_traces.md
@@ -11,12 +11,17 @@ The Atlas SDK ships with a standalone JSONL exporter so you can transform persis
 ## Basic Usage
 
 ```bash
-atlas.export \
+arc-atlas \
+  --database-url postgresql://atlas:atlas@localhost:5432/atlas \
+  --output traces.jsonl
+
+# Deterministic fallback that ignores shell PATH ordering
+python -m atlas.export.jsonl \
   --database-url postgresql://atlas:atlas@localhost:5432/atlas \
   --output traces.jsonl
 ```
 
-The command connects to the configured database, loads every stored session (or a filtered subset), and emits newline-delimited JSON. Friendly progress logs report how many sessions and steps were exported.
+The command connects to the configured database, loads every stored session (or a filtered subset), and emits newline-delimited JSON. Friendly progress logs report how many sessions and steps were exported. Compatibility aliases `atlas.export` / `atlas-export` still resolve to the same CLI, but `arc-atlas` (or the `python -m` form) avoids collisions with other tools named `atlas`.
 
 ### Useful Flags
 
@@ -46,7 +51,7 @@ Each line in `traces.jsonl` is an `AtlasSessionTrace`. The layout mirrors the da
 The exported file slots directly into the Atlas core training stack:
 
 1. Run `atlas.core.run(...)` to generate sessions and persist them to PostgreSQL.
-2. Execute `atlas.export --database-url ... --output traces.jsonl`.
+2. Execute `arc-atlas --database-url ... --output traces.jsonl` (or `python -m atlas.export.jsonl ...`).
 3. In the core repository, call `load_runtime_traces("traces.jsonl")` or `flatten_traces_for_training(...)` from `trainers/runtime_dataset.py`.
 
 This workflow keeps runtime telemetry decoupled from training data generation while reusing the shared schema consumed by the core trainers.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,11 +23,10 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Software Development :: Libraries",
 ]
-scripts = {
-    "atlas.export" = "atlas.export.jsonl:main",
-    "arc-atlas" = "atlas.export.jsonl:main",
-    "atlas-export" = "atlas.export.jsonl:main",
-}
+[project.scripts]
+"atlas.export" = "atlas.export.jsonl:main"
+"arc-atlas" = "atlas.export.jsonl:main"
+"atlas-export" = "atlas.export.jsonl:main"
 
 [project.optional-dependencies]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,11 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Software Development :: Libraries",
 ]
-scripts = { "atlas.export" = "atlas.export.jsonl:main" }
+scripts = {
+    "atlas.export" = "atlas.export.jsonl:main",
+    "arc-atlas" = "atlas.export.jsonl:main",
+    "atlas-export" = "atlas.export.jsonl:main",
+}
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
## Summary
- expose the JSONL exporter under the new  console alias while keeping existing  / 
- fix the pyproject script declaration so the new alias installs cleanly
- refresh README and export walkthrough docs to point at  plus the module fallback

## Testing
- python3.12 -m venv .venv && source .venv/bin/activate && pip install -e '.[dev]'
- arc-atlas --help
- python -m atlas.export.jsonl --help
- atlas.export --help
- arc-atlas --database-url postgresql://localhost:5432/nonexistent --output /tmp/qa_out.jsonl --limit 0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced arc-atlas as the primary CLI for exporting runtime-session JSONL traces.
  - Added compatibility aliases: atlas.export and atlas-export.
  - Provided a fallback invocation via python -m atlas.export.jsonl.

- Documentation
  - Updated guides and examples to use arc-atlas, with notes on alias compatibility and avoiding PATH collisions.
  - Expanded flag explanations, including --limit, --offset, --batch-size, and --trajectory-limit.

- Chores
  - Updated project packaging to register arc-atlas and atlas-export CLI entry points alongside atlas.export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->