### PR TITLE
feat: inject persona memories into prompts

### DIFF
--- a/atlas/core/__init__.py
+++ b/atlas/core/__init__.py
@@ -19,7 +19,15 @@ from atlas.prompts import (
 )
 from atlas.runtime.orchestration.execution_context import ExecutionContext
 from atlas.runtime.orchestration.orchestrator import Orchestrator
-from atlas.runtime.persona_memory import PersonaMemoryKey, build_fingerprint, extract_fingerprint_inputs, get_cache, is_cache_disabled
+from atlas.runtime.persona_memory import (
+    PersonaMemoryKey,
+    build_fingerprint,
+    extract_fingerprint_inputs,
+    get_cache,
+    is_cache_disabled,
+    merge_prompt,
+    normalize_instructions,
+)
 from atlas.evaluation.evaluator import Evaluator
 from atlas.personas.student import Student
 from atlas.personas.teacher import Teacher
@@ -59,7 +67,8 @@ async def arun(
     execution_context.metadata["persona_fingerprint_inputs"] = fingerprint_inputs
     persona_fingerprint = build_fingerprint(fingerprint_inputs)
     execution_context.metadata["persona_fingerprint"] = persona_fingerprint
-    execution_context.metadata.setdefault("persona_memories", {})
+    execution_context.metadata["persona_memories"] = {}
+    execution_context.metadata["applied_persona_memories"] = {}
     persona_cache = get_cache()
     cache_disabled = is_cache_disabled(config)
     if stream_progress is not None:
@@ -84,31 +93,15 @@ async def arun(
             "prompt_rewrite configuration is no longer supported. Remove the prompt_rewrite block "
             "from your Atlas config and rely on explicit student/teacher prompts."
         )
-    student_prompts = build_student_prompts(base_prompt, config.student)
-    teacher_prompts = build_teacher_prompts(base_prompt, config.teacher)
-    execution_context.metadata["prompt_rewrite"] = {
-        "student": student_prompts.__dict__,
-        "teacher": teacher_prompts.__dict__,
-    }
-    student = _build_student(adapter, config, student_prompts)
-    teacher = Teacher(config.teacher, teacher_prompts)
-    evaluator = Evaluator(config.rim)
-    orchestrator = Orchestrator(
-        teacher=teacher,
-        student=student,
-        evaluator=evaluator,
-        orchestration_config=config.orchestration,
-        rim_config=config.rim,
-    )
     database = Database(config.storage) if config.storage else None
     session_id: int | None = None
     try:
+        persona_memories = execution_context.metadata["persona_memories"]
         if database:
             await database.connect()
             metadata = execution_context.metadata.get("session_metadata")
             session_id = await database.create_session(task, metadata=metadata)
             if persona_fingerprint:
-                persona_memories = execution_context.metadata.setdefault("persona_memories", {})
                 statuses = ["active"]
                 use_cache = not cache_disabled
                 personas = [
@@ -138,9 +131,47 @@ async def arun(
                     "session-started",
                     {"session_id": session_id, "task": task},
                 )
+        student_prompts = build_student_prompts(base_prompt, config.student)
+        teacher_prompts = build_teacher_prompts(base_prompt, config.teacher)
+        instructions_map = {persona: normalize_instructions(records) for persona, records in persona_memories.items() if records}
+        applied_memories = execution_context.metadata["applied_persona_memories"]
+
+        def _apply_instructions(persona_id: str, prompt_text: str) -> str:
+            instructions = instructions_map.get(persona_id) or []
+            if not instructions:
+                return prompt_text
+            ids = [inst.memory_id for inst in instructions if inst.memory_id is not None]
+            applied_memories[persona_id] = list(dict.fromkeys(ids))
+            return merge_prompt(prompt_text, instructions)
+
+        student_prompts = RewrittenStudentPrompts(
+            planner=_apply_instructions("student_planner", student_prompts.planner),
+            executor=_apply_instructions("student_executor", student_prompts.executor),
+            synthesizer=_apply_instructions("student_synthesizer", student_prompts.synthesizer),
+        )
+        teacher_prompts = RewrittenTeacherPrompts(
+            plan_review=_apply_instructions("teacher_plan_review", teacher_prompts.plan_review),
+            validation=_apply_instructions("teacher_validation", teacher_prompts.validation),
+            guidance=_apply_instructions("teacher_guidance", teacher_prompts.guidance),
+        )
+        execution_context.metadata["prompt_rewrite"] = {
+            "student": student_prompts.__dict__,
+            "teacher": teacher_prompts.__dict__,
+        }
+        student = _build_student(adapter, config, student_prompts)
+        teacher = Teacher(config.teacher, teacher_prompts)
+        evaluator = Evaluator(config.rim)
+        orchestrator = Orchestrator(
+            teacher=teacher,
+            student=student,
+            evaluator=evaluator,
+            orchestration_config=config.orchestration,
+            rim_config=config.rim,
+        )
         result = await orchestrator.arun(task)
         if database and session_id is not None:
             await _persist_results(database, session_id, execution_context, result, events)
+            await _log_persona_memory_usage(database, session_id, execution_context)
             await database.finalize_session(session_id, result.final_answer, "succeeded")
             if publisher is not None:
                 publisher.publish_control_event(
@@ -157,6 +188,7 @@ async def arun(
     except Exception as exc:
         if database and session_id is not None:
             await _persist_events(database, session_id, events)
+            await _log_persona_memory_usage(database, session_id, execution_context)
             await database.finalize_session(session_id, "", "failed")
             if publisher is not None:
                 publisher.publish_control_event(
@@ -230,3 +262,15 @@ async def _persist_results(
 async def _persist_events(database: Database, session_id: int, events: List) -> None:
     for event in events:
         await database.log_intermediate_step(session_id, event)
+
+
+async def _log_persona_memory_usage(database: Database, session_id: int, context: ExecutionContext) -> None:
+    applied = context.metadata.get("applied_persona_memories") or {}
+    if not applied:
+        return
+    logged: set[Any] = set()
+    for memory_ids in applied.values():
+        for memory_id in memory_ids:
+            if memory_id and memory_id not in logged:
+                await database.log_persona_memory_usage(memory_id, session_id, reward=None, retries=None)
+                logged.add(memory_id)

--- a/atlas/runtime/persona_memory/__init__.py
+++ b/atlas/runtime/persona_memory/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from .cache import PersonaMemoryCache, PersonaMemoryKey, get_cache, is_cache_disabled
 from .fingerprint import FingerprintInputs, build_fingerprint, extract_fingerprint_inputs
+from .merge import PersonaMemoryInstruction, merge_prompt, normalize_instructions
 
 __all__ = [
     "FingerprintInputs",
@@ -13,4 +14,7 @@ __all__ = [
     "PersonaMemoryKey",
     "get_cache",
     "is_cache_disabled",
+    "PersonaMemoryInstruction",
+    "merge_prompt",
+    "normalize_instructions",
 ]

--- a/atlas/runtime/persona_memory/merge.py
+++ b/atlas/runtime/persona_memory/merge.py
@@ -1,0 +1,73 @@
+"""Helpers to merge persona memories into base prompts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Sequence
+
+
+@dataclass(frozen=True)
+class PersonaMemoryInstruction:
+    """Normalized persona memory instruction payload."""
+
+    memory_id: Any
+    created_at: Any
+    payload: Any
+
+
+def _render_instruction(base_prompt: str, instruction: Any) -> str:
+    if instruction is None:
+        return base_prompt
+    if isinstance(instruction, str):
+        return f"{base_prompt.strip()}\n\n--- Persona Memory ---\n{instruction.strip()}"
+    if isinstance(instruction, dict):
+        prepend = instruction.get("prepend")
+        append = instruction.get("append")
+        replace = instruction.get("replace")
+        parts: list[str] = []
+        if isinstance(prepend, str) and prepend.strip():
+            parts.append(prepend.strip())
+        if replace is not None:
+            if isinstance(replace, str):
+                parts.append(replace.strip())
+            elif isinstance(replace, dict):
+                parts.append(_render_instruction("", replace))
+            else:
+                parts.append(str(replace))
+            if isinstance(append, str) and append.strip():
+                parts.append(append.strip())
+            return "\n\n".join([part for part in parts if part])
+        base_clean = base_prompt.strip()
+        if base_clean:
+            parts.append(base_clean)
+        elif base_prompt and not parts:
+            parts.append(base_prompt)
+        if isinstance(append, str) and append.strip():
+            parts.append(append.strip())
+        return "\n\n".join([part for part in parts if part])
+    return f"{base_prompt.strip()}\n\n--- Persona Memory ---\n{str(instruction).strip()}"
+
+
+def merge_prompt(base_prompt: str, instructions: Sequence[PersonaMemoryInstruction]) -> str:
+    """Merge a base prompt with persona memories ordered by creation time."""
+    if not instructions:
+        return base_prompt
+    merged = base_prompt
+    ordered = sorted(instructions, key=lambda inst: inst.created_at or "")
+    for inst in ordered:
+        merged = _render_instruction(merged, inst.payload)
+    return merged
+
+
+def normalize_instructions(records: Iterable[Dict[str, Any]]) -> List[PersonaMemoryInstruction]:
+    """Convert persona memory rows into normalized instructions."""
+    result: List[PersonaMemoryInstruction] = []
+    for record in records:
+        result.append(
+            PersonaMemoryInstruction(
+                memory_id=record.get("memory_id"),
+                created_at=record.get("created_at"),
+                payload=record.get("instruction"),
+            )
+        )
+    return result

--- a/tests/integration/test_prompt_injection.py
+++ b/tests/integration/test_prompt_injection.py
@@ -1,0 +1,217 @@
+"""Integration tests covering runtime prompt injection with persona memories."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any, Dict, List
+from uuid import uuid4
+
+import pytest
+
+asyncpg = pytest.importorskip("asyncpg")
+
+from atlas import core
+from atlas.config.models import AdapterConfig, AdapterType, LLMParameters, OrchestrationConfig, RIMConfig, StorageConfig, StudentConfig, StudentPrompts, TeacherConfig, ToolDefinition
+from atlas.prompts import RewrittenStudentPrompts, RewrittenTeacherPrompts
+from atlas.runtime.orchestration.execution_context import ExecutionContext
+from atlas.runtime.persona_memory import build_fingerprint, extract_fingerprint_inputs, get_cache
+from atlas.runtime.storage.database import Database
+from atlas.types import Plan, Result
+
+pytestmark = pytest.mark.asyncio
+
+
+def _apply_schema_statements() -> List[str]:
+    schema_path = Path(__file__).resolve().parents[2] / "atlas" / "runtime" / "storage" / "schema.sql"
+    return [
+        statement.strip()
+        for statement in schema_path.read_text().split(";")
+        if statement.strip()
+    ]
+
+
+async def _apply_schema(database: Database) -> None:
+    pool = database._require_pool()  # noqa: SLF001 - integration test setup
+    statements = _apply_schema_statements()
+    async with pool.acquire() as connection:
+        for statement in statements:
+            await connection.execute(statement)
+
+
+class StubAdapter:
+    async def ainvoke(self, prompt: str, metadata=None):
+        return "{}"
+
+
+class CapturingStudent:
+    instances: List["CapturingStudent"] = []
+
+    def __init__(self, adapter, adapter_config, student_config, student_prompts: RewrittenStudentPrompts) -> None:
+        self.prompts = student_prompts
+        CapturingStudent.instances.append(self)
+
+
+class CapturingTeacher:
+    instances: List["CapturingTeacher"] = []
+
+    def __init__(self, config: TeacherConfig, prompts: RewrittenTeacherPrompts) -> None:
+        self.prompts = prompts
+        CapturingTeacher.instances.append(self)
+
+
+class StubEvaluator:
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+
+class StubOrchestrator:
+    def __init__(self, *args, **kwargs) -> None:
+        self.result = Result(final_answer="prompt injection complete", plan=Plan(steps=[]), step_results=[])
+
+    async def arun(self, task: str) -> Result:
+        return self.result
+
+
+async def test_prompt_injection_and_logging(monkeypatch: pytest.MonkeyPatch) -> None:
+    dsn = "postgresql://atlas:atlas@localhost:5433/atlas_arc_demo"
+    storage_config = StorageConfig(database_url=dsn, min_connections=1, max_connections=2)
+    database = Database(storage_config)
+    await database.connect()
+    await _apply_schema(database)
+    cache = get_cache()
+    cache.clear()
+    tenant_id = "tenant-persona-injection"
+    agent_name = "persona-agent"
+    tools = [
+        ToolDefinition(name="search", description="search tool"),
+        ToolDefinition(name="lookup", description="lookup tool"),
+    ]
+    # Compute fingerprint for seeding
+    context = ExecutionContext.get()
+    context.reset()
+    context.metadata["session_metadata"] = {"tenant_id": tenant_id, "tags": ["beta", "alpha"]}
+    context.metadata["execution_mode"] = "stepwise"
+    adapter_config = AdapterConfig(type=AdapterType.HTTP, name=agent_name, system_prompt="Base persona prompt", tools=tools)
+    atlas_config = type("Config", (), {"agent": adapter_config, "metadata": {"persona_memory": {}}})()
+    fingerprint_inputs = extract_fingerprint_inputs("seed-task", atlas_config, context)
+    fingerprint = build_fingerprint(fingerprint_inputs)
+    context.reset()
+
+    persona_payloads: Dict[str, List[Dict[str, Any]]] = {
+        "student_planner": [
+            {"instruction": {"prepend": "Planner persona preface."}},
+            {"instruction": "Always include citations."},
+        ],
+        "student_executor": [
+            {"instruction": {"append": "Report tool usage explicitly."}},
+        ],
+        "student_synthesizer": [
+            {"instruction": {"replace": "Provide a concise bullet summary reflecting persona memory."}},
+        ],
+        "teacher_plan_review": [
+            {"instruction": {"prepend": "Demand risk assessment before approval."}},
+        ],
+        "teacher_validation": [
+            {"instruction": {"append": "Request additional evidence when uncertain."}},
+        ],
+        "teacher_guidance": [
+            {"instruction": "Offer constructive encouragement in guidance."},
+        ],
+    }
+    persona_memory_ids: Dict[str, List[Any]] = {persona: [] for persona in persona_payloads}
+
+    pool = database._require_pool()  # noqa: SLF001 - integration test setup
+    async with pool.acquire() as connection:
+        await connection.execute(
+            "DELETE FROM persona_memory_usage USING persona_memory WHERE persona_memory_usage.memory_id = persona_memory.memory_id AND persona_memory.tenant_id = $1",
+            tenant_id,
+        )
+        await connection.execute("DELETE FROM persona_memory WHERE tenant_id = $1", tenant_id)
+    for persona, instructions in persona_payloads.items():
+        for payload in instructions:
+            memory_id = uuid4()
+            persona_memory_ids[persona].append(memory_id)
+            await database.create_persona_memory(
+                {
+                    "memory_id": memory_id,
+                    "agent_name": agent_name,
+                    "tenant_id": tenant_id,
+                    "persona": persona,
+                    "trigger_fingerprint": fingerprint,
+                    "instruction": payload["instruction"],
+                    "source_session_id": None,
+                    "reward_snapshot": None,
+                    "retry_count": None,
+                    "status": "active",
+                }
+            )
+    await database.disconnect()
+
+    CapturingStudent.instances.clear()
+    CapturingTeacher.instances.clear()
+    monkeypatch.delenv("ATLAS_PERSONA_MEMORY_CACHE_DISABLED", raising=False)
+    monkeypatch.setattr(core, "load_config", lambda path: type("ConfigWrapper", (), {
+        "agent": adapter_config,
+        "student": StudentConfig(prompts=StudentPrompts(planner="{base_prompt}", executor="{base_prompt}", synthesizer="{base_prompt}")),
+        "teacher": TeacherConfig(llm=LLMParameters(model="model")),
+        "orchestration": OrchestrationConfig(max_retries=0, step_timeout_seconds=10, rim_guidance_tag="tag", emit_intermediate_steps=True),
+        "rim": RIMConfig(
+            small_model=LLMParameters(model="stub"),
+            large_model=LLMParameters(model="arbiter"),
+            active_judges={"process": True},
+            variance_threshold=1.0,
+            uncertainty_threshold=1.0,
+            parallel_workers=1,
+        ),
+        "storage": storage_config,
+        "prompt_rewrite": None,
+        "metadata": {"persona_memory": {}},
+    })())
+    monkeypatch.setattr(core, "create_from_atlas_config", lambda config: StubAdapter())
+    monkeypatch.setattr(core, "Student", CapturingStudent)
+    monkeypatch.setattr(core, "Teacher", CapturingTeacher)
+    monkeypatch.setattr(core, "Evaluator", StubEvaluator)
+    monkeypatch.setattr(core, "Orchestrator", lambda *args, **kwargs: StubOrchestrator())
+
+    task_name = "prompt-injection-task"
+    run_start = time.perf_counter()
+    result = await core.arun(task_name, "config.yaml", session_metadata={"tenant_id": tenant_id, "tags": ["alpha", "beta"]})
+    duration_ms = (time.perf_counter() - run_start) * 1000.0
+    print(f"Prompt injection run completed in {duration_ms:.2f} ms")
+    assert result.final_answer == "prompt injection complete"
+
+    assert CapturingStudent.instances, "Student should be instantiated"
+    assert CapturingTeacher.instances, "Teacher should be instantiated"
+    student_prompts = CapturingStudent.instances[-1].prompts
+    teacher_prompts = CapturingTeacher.instances[-1].prompts
+
+    assert student_prompts.planner.lstrip().startswith("Planner persona preface.")
+    assert "Always include citations." in student_prompts.planner
+    assert student_prompts.executor.rstrip().endswith("Report tool usage explicitly.")
+    assert student_prompts.synthesizer.strip() == "Provide a concise bullet summary reflecting persona memory."
+    assert teacher_prompts.plan_review.lstrip().startswith("Demand risk assessment before approval.")
+    assert teacher_prompts.validation.rstrip().endswith("Request additional evidence when uncertain.")
+    assert "Offer constructive encouragement in guidance." in teacher_prompts.guidance
+
+    context = ExecutionContext.get()
+    applied = context.metadata.get("applied_persona_memories")
+    assert applied is not None
+    for persona, ids in persona_memory_ids.items():
+        assert applied.get(persona) == ids
+
+    verification_db = Database(storage_config)
+    await verification_db.connect()
+    sessions = await verification_db.fetch_sessions(limit=10)
+    session_entry = next(session for session in sessions if session["task"] == task_name)
+    session_id = session_entry["id"]
+    pool = verification_db._require_pool()  # noqa: SLF001 - integration test assertion
+    async with pool.acquire() as connection:
+        rows = await connection.fetch(
+            "SELECT memory_id FROM persona_memory_usage WHERE session_id = $1 ORDER BY memory_id",
+            session_id,
+        )
+    await verification_db.disconnect()
+    expected_ids = sorted({memory_id for ids in persona_memory_ids.values() for memory_id in ids})
+    logged_ids = sorted(row["memory_id"] for row in rows)
+    assert logged_ids == expected_ids

--- a/tests/unit/test_persona_memory_merge.py
+++ b/tests/unit/test_persona_memory_merge.py
@@ -1,0 +1,36 @@
+import datetime
+
+import pytest
+
+from atlas.runtime.persona_memory.merge import PersonaMemoryInstruction, merge_prompt, normalize_instructions
+
+
+def test_merge_prompt_with_string_and_dict_instructions():
+    base_prompt = "Base instructions"
+    instructions = [
+        PersonaMemoryInstruction(memory_id=1, created_at=datetime.datetime(2024, 1, 1), payload="Remember to cite sources."),
+        PersonaMemoryInstruction(memory_id=2, created_at=datetime.datetime(2024, 1, 2), payload={"prepend": "Act as a domain expert.", "append": "Summarize findings."}),
+    ]
+    merged = merge_prompt(base_prompt, instructions)
+    assert "Act as a domain expert." in merged.split("\n")[0]
+    assert "Remember to cite sources." in merged
+    assert merged.endswith("Summarize findings.")
+
+
+def test_merge_prompt_with_replace_instruction():
+    base_prompt = "Original"
+    instructions = [
+        PersonaMemoryInstruction(memory_id=1, created_at=datetime.datetime(2024, 1, 1), payload={"replace": "New base", "append": "Extra context"}),
+    ]
+    merged = merge_prompt(base_prompt, instructions)
+    assert merged == "New base\n\nExtra context"
+
+
+def test_normalize_instructions():
+    records = [
+        {"memory_id": "a", "created_at": "2024-01-01", "instruction": "note"},
+        {"memory_id": "b", "created_at": "2024-01-02", "instruction": {"append": "more"}},
+    ]
+    normalized = normalize_instructions(records)
+    assert normalized[0].memory_id == "a"
+    assert normalized[1].payload == {"append": "more"}


### PR DESCRIPTION
## Summary
- normalize persona memory instructions and merge them into student/teacher prompts before persona instantiation
- capture applied persona memory ids for each persona and persist them via the existing storage API
- add unit/integration coverage exercising prompt merging and logging with real Postgres runs

## Testing
- pytest tests/unit/test_persona_memory_merge.py
- pytest tests/integration/test_persona_memory.py
- pytest tests/integration/test_fingerprint_cache.py
- pytest tests/integration/test_prompt_injection.py
- pytest tests/integration/test_core.py

Resolves #33