### PR TITLE
Trial candidate persona memories automatically

### DIFF
--- a/atlas/runtime/persona_memory/merge.py
+++ b/atlas/runtime/persona_memory/merge.py
@@ -13,6 +13,7 @@ class PersonaMemoryInstruction:
     memory_id: Any
     created_at: Any
     payload: Any
+    status: str | None = None
 
 
 def _render_instruction(base_prompt: str, instruction: Any) -> str:
@@ -68,6 +69,7 @@ def normalize_instructions(records: Iterable[Dict[str, Any]]) -> List[PersonaMem
                 memory_id=record.get("memory_id"),
                 created_at=record.get("created_at"),
                 payload=record.get("instruction"),
+                status=record.get("status"),
             )
         )
     return result


### PR DESCRIPTION
## Summary
- fetch both active and candidate persona memories during prompt refresh so guidance generated on the previous run is trialed immediately
- record applied persona metadata with status labels and merge candidate instructions alongside actives, ensuring usage rows are written before promotion
- expand prompt injection regression to cover trial personas and verify usage logging, meeting the requirements in issue #42

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_persona_fingerprint_refresh.py tests/unit/export/test_jsonl_exporter.py tests/unit/telemetry/test_console.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin tests/integration/test_persona_learning_engine.py::test_persona_learning_engine_generates_candidates -vv -rs
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin -m postgres tests/integration/test_persona_promotion.py -vv -rs
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin -m postgres tests/integration/test_prompt_injection.py -vv -rs

Resolves #42.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Supports candidate (trial) persona instructions alongside active ones, enabling combined prompts per persona.
  - Prompts can include trial augmentations where applicable for richer, more adaptive responses.
  - Persona memories now track both ID and status, improving clarity in activity logs.

- Bug Fixes
  - Logging of persona memory usage is more robust and consistent across different entry formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->