### PR TITLE
Update probe LLM model and orchestrator final answer logic

### DIFF
--- a/atlas/core/__init__.py
+++ b/atlas/core/__init__.py
@@ -128,7 +128,6 @@ async def arun(
     teacher = Teacher(config.teacher, base_teacher_prompts, adapter_config.tools)
     evaluator = _build_evaluator_instance(config, getattr(adaptive_teaching_cfg, "reward", None))
     execution_context.metadata["adaptive_default_tags"] = list(getattr(adaptive_teaching_cfg, "default_tags", []) or [])
-    execution_context.metadata.setdefault("adaptive_certified_fingerprints", set())
     triage_adapter = _load_triage_adapter(getattr(adaptive_teaching_cfg, "triage_adapter", None))
     fingerprint_inputs: FingerprintInputs | None = extract_fingerprint_inputs(task, config, execution_context)
     persona_fingerprint: str | None = build_fingerprint(fingerprint_inputs)

--- a/atlas/runtime/adaptive/probe.py
+++ b/atlas/runtime/adaptive/probe.py
@@ -11,7 +11,7 @@ from atlas.utils.llm_client import LLMClient
 
 _DEFAULT_PROBE_LLM = LLMParameters(
     provider=LLMProvider.GOOGLE,
-    model="gemini-2.5-flash",
+    model="gemini/gemini-2.5-flash",
     api_key_env="GOOGLE_API_KEY",
     temperature=0.2,
     timeout_seconds=20.0,

--- a/atlas/runtime/orchestration/orchestrator.py
+++ b/atlas/runtime/orchestration/orchestrator.py
@@ -706,7 +706,8 @@ class Orchestrator:
         else:
             organized_results = sorted(step_summaries, key=lambda item: item.get("step_id", 0))
         context.metadata["single_shot_results"] = organized_results
-        final_answer = await self._student.asynthesize_final_answer(task, organized_results)
+        deliverable = outcome.deliverable or result.metadata.get("deliverable")
+        final_answer = deliverable if isinstance(deliverable, str) and deliverable.strip() else result.output
         return Result(final_answer=final_answer, plan=plan, step_results=step_results)
 
     async def _run_stepwise(self, task: str, plan: Plan) -> Result:


### PR DESCRIPTION
Changed the default probe LLM model name to 'gemini/gemini-2.5-flash' for consistency. Updated the orchestrator to use the deliverable as the final answer if available and non-empty, otherwise fallback to result output. Removed unused metadata initialization for adaptive_certified_fingerprints in core __init__.