### PR TITLE
Implement adapter sessions end-to-end

### DIFF
--- a/atlas/cli/jsonl_writer.py
+++ b/atlas/cli/jsonl_writer.py
@@ -348,6 +348,18 @@ def _enrich_session_metadata(
         session_metadata["created_at"] = _format_timestamp(created_at)
     if completed_at is not None and not session_metadata.get("completed_at"):
         session_metadata["completed_at"] = _format_timestamp(completed_at)
+    adapter_session_id = session_row.get("adapter_session_id")
+    adapter_usage = _coerce_json(session_row.get("adapter_usage"))
+    adapter_events = _coerce_json(session_row.get("adapter_events"))
+    if adapter_session_id is not None or adapter_usage or adapter_events:
+        adapter_meta = session_metadata.setdefault("adapter_session", {})
+        if isinstance(adapter_meta, dict):
+            if adapter_session_id is not None and "adapter_session_id" not in adapter_meta:
+                adapter_meta["adapter_session_id"] = adapter_session_id
+            if adapter_usage and "usage" not in adapter_meta:
+                adapter_meta["usage"] = adapter_usage
+            if adapter_events and "events" not in adapter_meta:
+                adapter_meta["events"] = adapter_events
 
     normalised_events = [_normalise_event(event) for event in reversed(events)]
     if normalised_events:
@@ -391,6 +403,15 @@ def _build_step_payload(
             attempts = len(attempt_details) or len(guidance) or 0
 
     metadata = _coerce_metadata(step_row.get("metadata"))
+    adapter_session_id = step_row.get("adapter_session_id")
+    adapter_usage = _coerce_json(step_row.get("adapter_usage"))
+    adapter_events = _coerce_json(step_row.get("adapter_events"))
+    if adapter_session_id and "adapter_session_id" not in metadata:
+        metadata["adapter_session_id"] = adapter_session_id
+    if adapter_usage and "usage" not in metadata:
+        metadata["usage"] = adapter_usage
+    if adapter_events and "adapter_events" not in metadata:
+        metadata["adapter_events"] = adapter_events
     if attempt_details:
         metadata.setdefault("attempt_history", attempt_details)
         metadata.setdefault("attempt_details", attempt_details)

--- a/atlas/connectors/README.md
+++ b/atlas/connectors/README.md
@@ -21,3 +21,44 @@ Related packages:
 
 - `atlas.personas` – consumes adapters for Student/Teacher personas.
 - `atlas.runtime.agent_loop` – executes adapter results within LangGraph.
+
+## Session-aware adapters
+
+Adapters can opt-in to stateful behaviour by implementing the session protocol:
+
+- Override `open_session(SessionContext) -> AgentSession` and set
+  `supports_sessions = True` (or inherit from
+  `StatefulAgentAdapterMixin`).
+- The returned `AgentSession` must expose a `session_id`, `metadata`,
+  `step(...)`, and `close(...)` method.
+- Stateless adapters remain compatible via the built-in `StatelessSession`
+  proxy, so existing integrations do not need to change.
+- `atlas.connectors.python.SessionResourcePool` helps share long-lived handles
+  (e.g. DB connections) across sessions.
+
+`SessionContext` captures the task identifier, execution mode, available tools,
+and arbitrary user context. When adapters expose sessions the runtime opens a
+single session per Atlas task and guarantees `close()` is called even if
+planning or execution fails.
+
+### Python adapter hooks
+
+The Python adapter automatically detects classes that implement
+`on_open`, `on_step`, and `on_close` hooks. The hooks run exactly once per
+session and can return additional metadata:
+
+```python
+class MyAgent:
+    async def on_open(self, context: SessionContext) -> dict:
+        self.cache = {...}
+        return {"ready": True}
+
+    async def on_step(self, prompt: str, metadata: dict | None = None):
+        return {"content": self.cache[prompt]}
+
+    async def on_close(self, reason: str | None = None):
+        self.cache.clear()
+```
+
+See `examples/stateful_adapter_sql` for a complete adapter that shares a SQLite
+connection across multiple steps.

--- a/atlas/connectors/http.py
+++ b/atlas/connectors/http.py
@@ -25,8 +25,12 @@ class HTTPAdapter(AgentAdapter):
     def _build_payload(self, prompt: str, metadata: Dict[str, Any] | None) -> Dict[str, Any]:
         payload = copy.deepcopy(self._config.payload_template)
         payload.setdefault("prompt", prompt)
-        if metadata:
-            payload.setdefault("metadata", metadata)
+        adapter_meta: Dict[str, Any] = dict(metadata or {})
+        session_id = adapter_meta.get("adapter_session_id")
+        if session_id is not None:
+            payload.setdefault("session_id", session_id)
+        if adapter_meta:
+            payload.setdefault("metadata", {}).update(adapter_meta)
         return payload
 
     def _extract_result(self, data: Any) -> str:

--- a/atlas/connectors/openai.py
+++ b/atlas/connectors/openai.py
@@ -173,6 +173,13 @@ class OpenAIAdapter(AgentAdapter):
         messages = self._build_messages(prompt, metadata)
         kwargs = self._base_kwargs()
         kwargs["messages"] = messages
+        metadata_payload = dict(metadata or {})
+        session_id = metadata_payload.get("adapter_session_id")
+        if session_id:
+            headers = dict(kwargs.get("extra_headers") or {})
+            headers.setdefault("X-Atlas-Session-Id", str(session_id))
+            kwargs["extra_headers"] = headers
+            metadata_payload.setdefault("session_id", session_id)
         try:
             response = await acompletion(**kwargs)
         except Exception as exc:

--- a/atlas/connectors/python.py
+++ b/atlas/connectors/python.py
@@ -7,21 +7,143 @@ import importlib
 import inspect
 import json
 import sys
-from typing import Any
-from typing import Dict
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Dict, Mapping, MutableMapping
+from uuid import uuid4
 
 from atlas.connectors.registry import AdapterError
 from atlas.connectors.registry import AgentAdapter
+from atlas.connectors.registry import AgentSession
+from atlas.connectors.registry import SessionContext
+from atlas.connectors.registry import StatelessSession
 from atlas.connectors.registry import register_adapter
 from atlas.config.models import AdapterType
 from atlas.config.models import PythonAdapterConfig
 
+
+@dataclass(slots=True)
+class _StatefulSpec:
+    factory: Callable[[], Any]
+    open_hook: str | None
+    step_hook: str
+    close_hook: str | None
+
+
+class SessionResourcePool:
+    """Simple async pool for sharing resources across stateful sessions."""
+
+    def __init__(self, factory: Callable[[], Awaitable[Any] | Any], *, max_size: int = 8) -> None:
+        self._factory = factory
+        self._max_size = max(1, max_size)
+        self._queue: asyncio.Queue[Any] = asyncio.Queue(max_size)
+        self._lock = asyncio.Lock()
+        self._created = 0
+
+    async def acquire(self) -> Any:
+        try:
+            return self._queue.get_nowait()
+        except asyncio.QueueEmpty:
+            pass
+        async with self._lock:
+            if self._created < self._max_size:
+                self._created += 1
+                return await _maybe_await(self._factory())
+        return await self._queue.get()
+
+    async def release(self, resource: Any) -> None:
+        if self._queue.full():
+            return
+        await self._queue.put(resource)
+
+    async def drain(self, disposer: Callable[[Any], Awaitable[None] | None] | None = None) -> None:
+        while not self._queue.empty():
+            resource = await self._queue.get()
+            if disposer is not None:
+                await _maybe_await(disposer(resource))
+
+
+async def _maybe_await(result: Any) -> Any:
+    if inspect.isawaitable(result):
+        return await result
+    return result
+
+
+class _PythonStatefulSession(AgentSession):
+    """Session wrapper for stateful Python classes implementing hook methods."""
+
+    def __init__(self, spec: _StatefulSpec, context: SessionContext) -> None:
+        self._spec = spec
+        self._context = context
+        self._instance: Any | None = None
+        self._metadata: MutableMapping[str, Any] = {}
+        self._session_id = context.session_id or f"python-{uuid4()}"
+
+    @property
+    def session_id(self) -> str:
+        return self._session_id
+
+    @property
+    def metadata(self) -> Mapping[str, Any]:
+        return self._metadata
+
+    async def open(self) -> None:
+        self._instance = self._spec.factory()
+        if inspect.isawaitable(self._instance):
+            self._instance = await self._instance
+        if self._spec.open_hook and self._instance is not None:
+            hook = getattr(self._instance, self._spec.open_hook)
+            result = await _maybe_await(hook(self._context))
+            if isinstance(result, Mapping):
+                self._metadata.update(result)
+            elif result is not None:
+                self._metadata["open_return"] = result
+
+    async def step(self, payload: str, metadata: Dict[str, Any] | None = None) -> Any:
+        if self._instance is None:
+            await self.open()
+        assert self._instance is not None  # for type checkers
+        hook = getattr(self._instance, self._spec.step_hook)
+        call_kwargs = {}
+        signature = inspect.signature(hook)
+        if "prompt" in signature.parameters:
+            call_kwargs["prompt"] = payload
+        if "payload" in signature.parameters and "prompt" not in signature.parameters:
+            call_kwargs["payload"] = payload
+        if "metadata" in signature.parameters:
+            call_kwargs["metadata"] = metadata
+        if not call_kwargs:
+            call_kwargs["prompt"] = payload
+        result = await _maybe_await(hook(**call_kwargs))
+        return result
+
+    async def close(self, reason: str | None = None) -> Mapping[str, Any] | None:
+        if self._instance is None:
+            return self._metadata
+        if not self._spec.close_hook:
+            return self._metadata
+        hook = getattr(self._instance, self._spec.close_hook)
+        signature = inspect.signature(hook)
+        call_kwargs = {}
+        if "reason" in signature.parameters:
+            call_kwargs["reason"] = reason
+        if "context" in signature.parameters:
+            call_kwargs["context"] = self._context
+        result = await _maybe_await(hook(**call_kwargs))
+        if isinstance(result, Mapping):
+            self._metadata.update(result)
+        return self._metadata
+
+
 class PythonAdapter(AgentAdapter):
-    """Adapter that calls a user supplied Python function."""
+    """Adapter that calls a user supplied Python function or session-aware class."""
 
     def __init__(self, config: PythonAdapterConfig):
         self._config = config
-        self._callable = self._load_callable()
+        self._target = self._load_callable()
+        self._stateful_spec = self._detect_stateful_target(self._target)
+        if self._stateful_spec is not None:
+            self.supports_sessions = True
+
     def _load_callable(self):
         module_path = self._config.import_path
         working_dir = self._config.working_directory
@@ -39,6 +161,23 @@ class PythonAdapter(AgentAdapter):
         if not callable(target):
             raise AdapterError(f"attribute '{attr_name}' is not callable")
         return target
+
+    def _detect_stateful_target(self, target: Any) -> _StatefulSpec | None:
+        if not inspect.isclass(target):
+            return None
+        open_hook = self._first_hook(target, ["on_open", "open", "start"])
+        step_hook = self._first_hook(target, ["on_step", "step", "run", "__call__"])
+        close_hook = self._first_hook(target, ["on_close", "close", "shutdown", "stop"])
+        if step_hook is None:
+            return None
+        return _StatefulSpec(factory=target, open_hook=open_hook, step_hook=step_hook, close_hook=close_hook)
+
+    def _first_hook(self, target: Any, names: list[str]) -> str | None:
+        for name in names:
+            if hasattr(target, name) and callable(getattr(target, name)):
+                return name
+        return None
+
     async def _normalise_result(self, result: Any) -> str:
         if inspect.isasyncgen(result):
             if not self._config.allow_generator:
@@ -56,16 +195,37 @@ class PythonAdapter(AgentAdapter):
         if isinstance(result, (dict, list)):
             return json.dumps(result)
         return str(result)
+
     def _call_sync(self, prompt: str, metadata: Dict[str, Any] | None) -> Any:
         try:
-            return self._callable(prompt=prompt, metadata=metadata)
-        except Exception as exc:
+            return self._target(prompt=prompt, metadata=metadata)
+        except Exception as exc:  # pragma: no cover - best effort
             raise AdapterError(f"python adapter callable raised an exception: {exc}") from exc
+
+    async def _call_stateful_once(self, prompt: str, metadata: Dict[str, Any] | None) -> Any:
+        context = self._context_from_metadata(metadata)
+        session = await self.open_session(context)
+        try:
+            return await session.step(prompt, metadata)
+        finally:
+            await session.close(reason="adhoc")
+
+    def _context_from_metadata(self, metadata: Dict[str, Any] | None) -> SessionContext:
+        payload = dict(metadata or {})
+        task_id = str(payload.get("task_id") or payload.get("task") or uuid4())
+        execution_mode = str(payload.get("mode") or payload.get("execution_mode") or "adhoc")
+        tool_meta = payload.get("tool_metadata")
+        user_ctx = payload.get("user_context")
+        return SessionContext(task_id=task_id, execution_mode=execution_mode, tool_metadata=tool_meta, user_context=user_ctx)
+
     async def ainvoke(self, prompt: str, metadata: Dict[str, Any] | None = None) -> str:
-        call_metadata = metadata or {}
+        call_metadata = dict(metadata or {})
         if self._config.llm:
-            call_metadata["llm_config"] = self._config.llm.model_dump()
-        func = self._callable
+            call_metadata.setdefault("llm_config", self._config.llm.model_dump())
+        if self._stateful_spec is not None:
+            result = await self._call_stateful_once(prompt, call_metadata)
+            return await self._normalise_result(result)
+        func = self._target
         if inspect.iscoroutinefunction(func):
             try:
                 result = await func(prompt=prompt, metadata=call_metadata)
@@ -75,6 +235,14 @@ class PythonAdapter(AgentAdapter):
             result = await asyncio.to_thread(self._call_sync, prompt, call_metadata)
         return await self._normalise_result(result)
 
+    async def open_session(self, context: SessionContext) -> AgentSession:
+        if self._stateful_spec is None:
+            return StatelessSession(self, context)
+        session = _PythonStatefulSession(self._stateful_spec, context)
+        await session.open()
+        return session
+
+
 register_adapter(AdapterType.PYTHON, PythonAdapter)
 
-__all__ = ["PythonAdapter"]
+__all__ = ["PythonAdapter", "SessionResourcePool"]

--- a/atlas/connectors/registry.py
+++ b/atlas/connectors/registry.py
@@ -1,35 +1,132 @@
-"""Adapter registry for Bring-Your-Own-Agent integrations."""
+"""Adapter registry and session primitives for Bring-Your-Own-Agent integrations."""
 
 from __future__ import annotations
 
 import asyncio
-from typing import Any
-from typing import Callable
-from typing import Dict
+import contextlib
+from dataclasses import dataclass, field
+from typing import Any, AsyncIterator, Callable, Dict, Mapping, MutableMapping, Protocol
+from uuid import uuid4
 
 from atlas.config.models import AdapterType
 from atlas.config.models import AdapterUnion
+
 
 class AdapterError(RuntimeError):
     """Raised when adapter execution fails."""
 
 
+@dataclass(slots=True)
+class SessionContext:
+    """Container describing the runtime state for an adapter session."""
+
+    task_id: str
+    execution_mode: str
+    tool_metadata: Mapping[str, Any] | None = None
+    user_context: Mapping[str, Any] | None = None
+    session_id: str | None = None
+    extra: MutableMapping[str, Any] = field(default_factory=dict)
+
+
+class AgentSession(Protocol):
+    """Protocol implemented by adapter sessions."""
+
+    session_id: str
+    metadata: Mapping[str, Any]
+
+    async def step(self, payload: str, metadata: Dict[str, Any] | None = None) -> Any:  # pragma: no cover - interface
+        """Execute a single adapter step."""
+
+    async def close(self, reason: str | None = None) -> Mapping[str, Any] | None:  # pragma: no cover - interface
+        """Release resources associated with the session."""
+
+
+@dataclass(slots=True)
+class StatelessSession:
+    """Fallback session that proxies calls to :meth:`AgentAdapter.ainvoke`."""
+
+    adapter: "AgentAdapter"
+    context: SessionContext
+    _session_id: str = field(init=False)
+    _metadata: dict[str, Any] = field(init=False)
+
+    def __post_init__(self) -> None:
+        self._session_id = self.context.session_id or f"stateless-{uuid4()}"
+        metadata: dict[str, Any] = {
+            "mode": self.context.execution_mode,
+            "task_id": self.context.task_id,
+        }
+        if self.context.user_context:
+            metadata["user_context"] = dict(self.context.user_context)
+        if self.context.tool_metadata:
+            metadata["tool_metadata"] = dict(self.context.tool_metadata)
+        metadata.update(self.context.extra)
+        self._metadata = metadata
+
+    @property
+    def session_id(self) -> str:
+        return self._session_id
+
+    @property
+    def metadata(self) -> Mapping[str, Any]:
+        return self._metadata
+
+    async def step(self, payload: str, metadata: Dict[str, Any] | None = None) -> Any:
+        merged = dict(metadata or {})
+        merged.setdefault("adapter_session_id", self.session_id)
+        return await self.adapter.ainvoke(payload, metadata=merged)
+
+    async def close(self, reason: str | None = None) -> Mapping[str, Any] | None:  # pragma: no cover - trivial
+        return None
+
+
 class AgentAdapter:
     """Abstract adapter providing synchronous and asynchronous entrypoints."""
 
-    async def ainvoke(self, prompt: str, metadata: Dict[str, Any] | None = None) -> str:
+    supports_sessions: bool = False
+
+    async def ainvoke(self, prompt: str, metadata: Dict[str, Any] | None = None) -> Any:
         raise NotImplementedError
 
-    def execute(self, prompt: str, metadata: Dict[str, Any] | None = None) -> str:
+    async def open_session(self, context: SessionContext) -> AgentSession:
+        """Open a new session for adapters that support state."""
+
+        return StatelessSession(self, context)
+
+    def execute(self, prompt: str, metadata: Dict[str, Any] | None = None) -> Any:
         try:
             asyncio.get_running_loop()
         except RuntimeError:
             return asyncio.run(self.ainvoke(prompt, metadata))
         raise AdapterError("execute cannot be used inside a running event loop; use ainvoke instead")
 
+
+class StatefulAgentAdapterMixin:
+    """Mixin that provides convenience helpers for session-aware adapters."""
+
+    supports_sessions: bool = True
+
+    async def open_session(self, context: SessionContext) -> AgentSession:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    @contextlib.asynccontextmanager
+    async def session(self, context: SessionContext) -> AsyncIterator[AgentSession]:
+        session = await self.open_session(context)
+        try:
+            yield session
+        except Exception as exc:  # pragma: no cover - defensive cleanup
+            with contextlib.suppress(Exception):
+                await session.close(reason=str(exc))
+            raise
+        else:
+            with contextlib.suppress(Exception):
+                await session.close()
+
+
 AdapterBuilder = Callable[[AdapterUnion], AgentAdapter]
 
 _ADAPTER_BUILDERS: Dict[AdapterType, AdapterBuilder] = {}
+
 
 def register_adapter(adapter_type: AdapterType, builder: AdapterBuilder) -> None:
     _ADAPTER_BUILDERS[adapter_type] = builder
@@ -38,7 +135,7 @@ def register_adapter(adapter_type: AdapterType, builder: AdapterBuilder) -> None
 def get_adapter_builder(adapter_type: AdapterType) -> AdapterBuilder:
     try:
         return _ADAPTER_BUILDERS[adapter_type]
-    except KeyError as exc:
+    except KeyError as exc:  # pragma: no cover - defensive
         raise AdapterError(f"no adapter registered for type {adapter_type.value}") from exc
 
 
@@ -46,9 +143,14 @@ def build_adapter(config: AdapterUnion) -> AgentAdapter:
     builder = get_adapter_builder(config.type)
     return builder(config)
 
+
 __all__ = [
     "AdapterError",
     "AgentAdapter",
+    "AgentSession",
+    "SessionContext",
+    "StatefulAgentAdapterMixin",
+    "StatelessSession",
     "register_adapter",
     "get_adapter_builder",
     "build_adapter",

--- a/atlas/runtime/models/intermediate_step.py
+++ b/atlas/runtime/models/intermediate_step.py
@@ -26,6 +26,7 @@ class IntermediateStepCategory(str, Enum):
     FUNCTION = "FUNCTION"
     CUSTOM = "CUSTOM"
     SPAN = "SPAN"
+    SESSION = "SESSION"
 
 
 class IntermediateStepType(str, Enum):
@@ -45,6 +46,8 @@ class IntermediateStepType(str, Enum):
     SPAN_START = "SPAN_START"
     SPAN_CHUNK = "SPAN_CHUNK"
     SPAN_END = "SPAN_END"
+    SESSION_OPENED = "SESSION_OPENED"
+    SESSION_CLOSED = "SESSION_CLOSED"
 
 
 class IntermediateStepState(str, Enum):
@@ -134,6 +137,8 @@ class IntermediateStepPayload(BaseModel):
             IntermediateStepType.SPAN_START: IntermediateStepCategory.SPAN,
             IntermediateStepType.SPAN_CHUNK: IntermediateStepCategory.SPAN,
             IntermediateStepType.SPAN_END: IntermediateStepCategory.SPAN,
+            IntermediateStepType.SESSION_OPENED: IntermediateStepCategory.SESSION,
+            IntermediateStepType.SESSION_CLOSED: IntermediateStepCategory.SESSION,
         }
         return mapping[self.event_type]
 
@@ -156,6 +161,8 @@ class IntermediateStepPayload(BaseModel):
             IntermediateStepType.SPAN_START: IntermediateStepState.START,
             IntermediateStepType.SPAN_CHUNK: IntermediateStepState.CHUNK,
             IntermediateStepType.SPAN_END: IntermediateStepState.END,
+            IntermediateStepType.SESSION_OPENED: IntermediateStepState.START,
+            IntermediateStepType.SESSION_CLOSED: IntermediateStepState.END,
         }
         return mapping[self.event_type]
 

--- a/atlas/runtime/storage/database.py
+++ b/atlas/runtime/storage/database.py
@@ -79,13 +79,26 @@ class Database:
             evaluation_payload = result.evaluation
         serialized_evaluation = self._serialize_json(evaluation_payload)
         serialized_metadata = self._serialize_json(result.metadata) if getattr(result, "metadata", None) else None
+        adapter_session_id = None
+        adapter_usage_json = None
+        adapter_events_json = None
+        if isinstance(result.metadata, dict):
+            adapter_session_id = result.metadata.get("adapter_session_id")
+            usage_payload = result.metadata.get("usage")
+            events_payload = result.metadata.get("adapter_events")
+            if usage_payload is not None:
+                adapter_usage_json = self._serialize_json(usage_payload)
+            if events_payload is not None:
+                adapter_events_json = self._serialize_json(events_payload)
         async with pool.acquire() as connection:
             await connection.execute(
-                "INSERT INTO step_results(session_id, step_id, trace, output, evaluation, attempts, metadata)"
-                " VALUES ($1, $2, $3, $4, $5, $6, $7)"
+                "INSERT INTO step_results(session_id, step_id, trace, output, evaluation, attempts, metadata, adapter_session_id, adapter_usage, adapter_events)"
+                " VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)"
                 " ON CONFLICT (session_id, step_id) DO UPDATE SET"
                 " trace = EXCLUDED.trace, output = EXCLUDED.output, evaluation = EXCLUDED.evaluation,"
-                " attempts = EXCLUDED.attempts, metadata = EXCLUDED.metadata",
+                " attempts = EXCLUDED.attempts, metadata = EXCLUDED.metadata,"
+                " adapter_session_id = EXCLUDED.adapter_session_id,"
+                " adapter_usage = EXCLUDED.adapter_usage, adapter_events = EXCLUDED.adapter_events",
                 session_id,
                 result.step_id,
                 result.trace,
@@ -93,6 +106,9 @@ class Database:
                 serialized_evaluation,
                 result.attempts,
                 serialized_metadata,
+                adapter_session_id,
+                adapter_usage_json,
+                adapter_events_json,
             )
 
     async def log_step_attempts(
@@ -175,7 +191,7 @@ class Database:
         pool = self._require_pool()
         async with pool.acquire() as connection:
             rows = await connection.fetch(
-                "SELECT id, task, status, metadata, final_answer, reward, student_learning, teacher_learning, created_at, completed_at"
+                "SELECT id, task, status, metadata, adapter_session_id, adapter_usage, adapter_events, final_answer, reward, student_learning, teacher_learning, created_at, completed_at"
                 " FROM sessions ORDER BY created_at DESC LIMIT $1 OFFSET $2",
                 limit,
                 offset,
@@ -186,7 +202,7 @@ class Database:
         pool = self._require_pool()
         async with pool.acquire() as connection:
             row = await connection.fetchrow(
-                "SELECT id, task, status, metadata, final_answer, reward, student_learning, teacher_learning, created_at, completed_at"
+                "SELECT id, task, status, metadata, adapter_session_id, adapter_usage, adapter_events, final_answer, reward, student_learning, teacher_learning, created_at, completed_at"
                 " FROM sessions WHERE id = $1",
                 session_id,
             )
@@ -215,7 +231,7 @@ class Database:
         pool = self._require_pool()
         async with pool.acquire() as connection:
             step_rows = await connection.fetch(
-                "SELECT step_id, trace, output, evaluation, attempts, metadata"
+                "SELECT step_id, trace, output, evaluation, attempts, metadata, adapter_session_id, adapter_usage, adapter_events"
                 " FROM step_results WHERE session_id = $1 ORDER BY step_id",
                 session_id,
             )
@@ -248,6 +264,9 @@ class Database:
                     "evaluation": row["evaluation"],
                     "attempts": row["attempts"],
                     "metadata": row["metadata"],
+                    "adapter_session_id": row.get("adapter_session_id"),
+                    "adapter_usage": row.get("adapter_usage"),
+                    "adapter_events": row.get("adapter_events"),
                     "attempt_details": attempts_by_step.get(step_id, []),
                     "guidance_notes": guidance_by_step.get(step_id, []),
                 }
@@ -295,11 +314,27 @@ class Database:
         """Replace metadata payload for a session."""
         pool = self._require_pool()
         payload = self._serialize_json(metadata) if metadata is not None else None
+        adapter_session_id = None
+        adapter_usage_json = None
+        adapter_events_json = None
+        if isinstance(metadata, dict):
+            adapter_meta = metadata.get("adapter_session")
+            if isinstance(adapter_meta, dict):
+                adapter_session_id = adapter_meta.get("adapter_session_id")
+                usage_payload = adapter_meta.get("usage")
+                events_payload = adapter_meta.get("events")
+                if usage_payload is not None:
+                    adapter_usage_json = self._serialize_json(usage_payload)
+                if events_payload is not None:
+                    adapter_events_json = self._serialize_json(events_payload)
         async with pool.acquire() as connection:
             await connection.execute(
-                "UPDATE sessions SET metadata = $2 WHERE id = $1",
+                "UPDATE sessions SET metadata = $2, adapter_session_id = $3, adapter_usage = $4, adapter_events = $5 WHERE id = $1",
                 session_id,
                 payload,
+                adapter_session_id,
+                adapter_usage_json,
+                adapter_events_json,
             )
 
     def _require_pool(self) -> asyncpg.Pool:

--- a/atlas/runtime/storage/schema.sql
+++ b/atlas/runtime/storage/schema.sql
@@ -3,6 +3,9 @@ CREATE TABLE IF NOT EXISTS sessions (
     task TEXT NOT NULL,
     status TEXT NOT NULL DEFAULT 'running',
     metadata JSONB,
+    adapter_session_id TEXT,
+    adapter_usage JSONB,
+    adapter_events JSONB,
     final_answer TEXT,
     reward JSONB,
     student_learning TEXT,
@@ -27,6 +30,9 @@ CREATE TABLE IF NOT EXISTS step_results (
     evaluation JSONB,
     attempts INTEGER,
     metadata JSONB,
+    adapter_session_id TEXT,
+    adapter_usage JSONB,
+    adapter_events JSONB,
     PRIMARY KEY (session_id, step_id)
 );
 

--- a/docs/examples/export_runtime_traces.md
+++ b/docs/examples/export_runtime_traces.md
@@ -45,7 +45,8 @@ Each line in `traces.jsonl` is an `AtlasSessionTrace`. The layout mirrors the da
   - `validation` results from the Teacher and `guidance` history.
   - `context.prior_results` containing outputs from prior steps.
   - `metadata` with retry attempt payloads and dependency hints.
-- `session_metadata` – includes persisted metadata, execution status, timestamps, and the ordered list of trajectory events recorded during orchestration.
+  - `adapter_session_id`, `adapter_usage`, and `adapter_events` for each step.
+- `session_metadata` – includes persisted metadata, execution status, timestamps, and the ordered list of trajectory events recorded during orchestration. The `adapter_session` payload mirrors the per-step metrics and is keyed by the runtime session ID.
 
 ## Training Workflow
 

--- a/docs/examples/stateful_sessions.md
+++ b/docs/examples/stateful_sessions.md
@@ -1,0 +1,69 @@
+# Stateful adapter sessions
+
+Atlas now opens a single adapter session for each runtime task (plan → execute
+→ synthesize). Adapters that expose the session interface can reuse expensive
+resources and emit richer telemetry for continual learning.
+
+## Authoring a stateful adapter
+
+1. Implement `open_session(SessionContext)` and return an object exposing
+   `session_id`, `metadata`, `step(...)`, and `close(...)`. The base
+   `StatelessSession` proxy keeps existing adapters working without any
+   changes.
+2. Inherit from `StatefulAgentAdapterMixin` or set `supports_sessions = True` to
+   let the runtime know sessions are available.
+3. Propagate `adapter_session_id` inside `metadata` when calling external
+   services so telemetry can be stitched back together later.
+
+```python
+from atlas.connectors.registry import AgentAdapter, SessionContext
+
+class MyAdapter(StatefulAgentAdapterMixin, AgentAdapter):
+    async def open_session(self, context: SessionContext):
+        return MySession(context)
+```
+
+The Python adapter automatically detects classes with `on_open`, `on_step`, and
+`on_close` hooks. See `examples/stateful_adapter_sql/` for a working SQLite
+example.
+
+## Using sessions from the runtime
+
+The Student persona manages sessions via `async with student.session_scope(...)`
+so adapters see a single logical conversation. Standalone adapters can use the
+same pattern:
+
+```python
+async with adapter.session(SessionContext(task_id="demo", execution_mode="stepwise")) as session:
+    first = await session.step("plan")
+    second = await session.step("execute", metadata={"adapter_session_id": session.session_id})
+```
+
+Every call returns usage and tool events which the runtime aggregates into
+`context.metadata["adapter_session"]`. The JSONL exporter now includes:
+
+- `adapter_session_id`
+- `adapter_usage` (prompt/completion tokens, call count)
+- `adapter_events` (tool invocations, environment actions)
+
+These fields make it easy to join runtime traces with the GRPO / RIM continual
+learning pipelines described in the Atlas foundation paper.
+
+## Database migration
+
+Existing deployments should add the following columns:
+
+```sql
+ALTER TABLE sessions
+    ADD COLUMN IF NOT EXISTS adapter_session_id TEXT,
+    ADD COLUMN IF NOT EXISTS adapter_usage JSONB,
+    ADD COLUMN IF NOT EXISTS adapter_events JSONB;
+
+ALTER TABLE step_results
+    ADD COLUMN IF NOT EXISTS adapter_session_id TEXT,
+    ADD COLUMN IF NOT EXISTS adapter_usage JSONB,
+    ADD COLUMN IF NOT EXISTS adapter_events JSONB;
+```
+
+Restart the runtime after applying the migration so new telemetry is persisted
+automatically.

--- a/examples/stateful_adapter_sql/README.md
+++ b/examples/stateful_adapter_sql/README.md
@@ -1,0 +1,29 @@
+# Stateful Python adapter example
+
+This example shows how to build a stateful Python adapter that keeps a database
+connection alive across multiple steps. The `SQLiteAgent` class exposes
+`on_open`, `on_step`, and `on_close` hooks – when it is loaded through the
+`PythonAdapter` the hooks are invoked for each `SessionContext` so the agent can
+reuse connections and emit structured telemetry.
+
+```python
+from atlas.connectors.python import PythonAdapter
+from atlas.config.models import AdapterType, PythonAdapterConfig
+from atlas.connectors.registry import SessionContext
+
+config = PythonAdapterConfig(
+    type=AdapterType.PYTHON,
+    name="sqlite-agent",
+    system_prompt="",
+    import_path="examples.stateful_adapter_sql.adapter",
+    attribute="SQLiteAgent",
+)
+adapter = PythonAdapter(config)
+
+session = await adapter.open_session(SessionContext(task_id="demo", execution_mode="stepwise"))
+rows = await session.step("SELECT title FROM documents ORDER BY id")
+await session.close()
+```
+
+See `tests/unit/test_adapter_sessions.py` for an end-to-end usage example that
+verifies the session metadata captured by the runtime.

--- a/examples/stateful_adapter_sql/adapter.py
+++ b/examples/stateful_adapter_sql/adapter.py
@@ -1,0 +1,53 @@
+"""Example stateful adapter that keeps a SQLite connection per session."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+from atlas.connectors.registry import SessionContext
+
+
+class SQLiteAgent:
+    """Simple stateful adapter that reuses an in-memory SQLite database."""
+
+    def __init__(self) -> None:
+        self._connection: sqlite3.Connection | None = None
+        self._session_id: str | None = None
+
+    async def on_open(self, context: SessionContext) -> dict[str, Any]:
+        self._connection = sqlite3.connect(":memory:")
+        self._session_id = context.session_id
+        cursor = self._connection.cursor()
+        cursor.execute("CREATE TABLE documents (id INTEGER PRIMARY KEY, title TEXT)")
+        cursor.executemany(
+            "INSERT INTO documents(title) VALUES (?)",
+            [("Atlas SDK",), ("Continual Learning",), ("Stateful Sessions",)],
+        )
+        self._connection.commit()
+        return {
+            "database": "sqlite",
+            "rows": 3,
+            "session_id": self._session_id,
+        }
+
+    async def on_step(self, prompt: str, metadata: dict[str, Any] | None = None) -> dict[str, Any]:
+        if self._connection is None:
+            raise RuntimeError("SQLiteAgent session has not been opened")
+        cursor = self._connection.cursor()
+        cursor.execute(prompt)
+        rows = cursor.fetchall()
+        return {
+            "content": rows,
+            "usage": {"prompt_tokens": 1, "completion_tokens": len(rows), "total_tokens": len(rows) + 1},
+            "events": [{"type": "sql", "query": prompt}],
+        }
+
+    async def on_close(self, reason: str | None = None) -> dict[str, Any]:
+        if self._connection is not None:
+            self._connection.close()
+            self._connection = None
+        return {"closed": True, "reason": reason, "session_id": self._session_id}
+
+
+__all__ = ["SQLiteAgent"]

--- a/examples/stateful_adapter_sql/test_adapter.py
+++ b/examples/stateful_adapter_sql/test_adapter.py
@@ -1,0 +1,27 @@
+import pytest
+
+from atlas.connectors.python import PythonAdapter
+from atlas.config.models import AdapterType, PythonAdapterConfig
+from atlas.connectors.registry import SessionContext
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_sqlite_agent_session():
+    config = PythonAdapterConfig(
+        type=AdapterType.PYTHON,
+        name="sqlite-agent",
+        system_prompt="",
+        import_path="examples.stateful_adapter_sql.adapter",
+        attribute="SQLiteAgent",
+    )
+    adapter = PythonAdapter(config)
+    session = await adapter.open_session(SessionContext(task_id="sqlite", execution_mode="stepwise"))
+    rows = await session.step("SELECT title FROM documents ORDER BY id")
+    assert rows["content"][0][0] == "Atlas SDK"
+    metadata = await session.close(reason="test")
+    assert metadata["closed"] is True

--- a/tests/unit/test_adapter_sessions.py
+++ b/tests/unit/test_adapter_sessions.py
@@ -1,0 +1,158 @@
+import asyncio
+import asyncio
+import sys
+from types import ModuleType
+
+import pytest
+
+from atlas.connectors.python import PythonAdapter
+from atlas.connectors.registry import AgentAdapter
+from atlas.connectors.registry import SessionContext
+from atlas.connectors.registry import StatelessSession
+from atlas.config.models import AdapterConfig
+from atlas.config.models import AdapterType
+from atlas.config.models import PythonAdapterConfig
+from atlas.config.models import StudentConfig
+from atlas.config.models import StudentPrompts
+from atlas.personas.student import Student
+from atlas.prompts import build_student_prompts
+from atlas.runtime.orchestration.execution_context import ExecutionContext
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+class _EchoAdapter(AgentAdapter):
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    async def ainvoke(self, prompt: str, metadata: dict | None = None) -> str:
+        self.calls.append(dict(metadata or {}))
+        return prompt.upper()
+
+
+def test_stateless_session_injects_metadata():
+    adapter = _EchoAdapter()
+    context = SessionContext(task_id="task-1", execution_mode="plan")
+    session = StatelessSession(adapter, context)
+
+    result = asyncio.run(session.step("hello", {}))
+
+    assert result == "HELLO"
+    assert adapter.calls, "adapter should have been invoked"
+    assert "adapter_session_id" in adapter.calls[0]
+
+
+def test_python_adapter_stateful_hooks(monkeypatch):
+    module = ModuleType("_stateful_adapter_module")
+
+    class StatefulAgent:
+        def __init__(self) -> None:
+            self.counter = 0
+            self.closed_with: str | None = None
+
+        async def on_open(self, context: SessionContext) -> dict[str, str]:
+            return {"opened": context.task_id}
+
+        async def on_step(self, prompt: str, metadata: dict | None = None) -> dict:
+            self.counter += 1
+            return {"content": prompt, "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}}
+
+        async def on_close(self, reason: str | None = None) -> None:
+            self.closed_with = reason
+
+    module.StatefulAgent = StatefulAgent
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+
+    adapter_config = PythonAdapterConfig(
+        type=AdapterType.PYTHON,
+        name="stateful",
+        system_prompt="",
+        import_path=module.__name__,
+        attribute="StatefulAgent",
+    )
+    adapter = PythonAdapter(adapter_config)
+    assert adapter.supports_sessions is True
+
+    session_context = SessionContext(task_id="unit", execution_mode="test")
+    session = asyncio.run(adapter.open_session(session_context))
+    assert session.metadata.get("opened") == "unit"
+
+    first = asyncio.run(session.step("ping", {}))
+    second = asyncio.run(session.step("pong", {}))
+    assert first["content"] == "ping"
+    assert second["content"] == "pong"
+    asyncio.run(session.close(reason="finished"))
+
+
+@pytest.mark.anyio("asyncio")
+async def test_student_session_scope_tracks_usage():
+    class StubSession:
+        def __init__(self) -> None:
+            self.session_id = "stub-session"
+            self.metadata = {"stub": True}
+            self.calls: list[str] = []
+
+        async def step(self, payload: str, metadata: dict | None = None) -> dict[str, object]:
+            self.calls.append(payload)
+            if len(self.calls) == 1:
+                return {
+                    "content": "{\"steps\":[{\"id\":1,\"description\":\"Do\",\"tool\":null,\"tool_params\":null,\"depends_on\":[]}]}",
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+                    "events": [{"type": "completion", "stage": "plan"}],
+                }
+            return {
+                "content": "Final answer",
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            }
+
+        async def close(self, reason: str | None = None) -> dict[str, object]:
+            return {"closed": reason}
+
+    class StubAdapter(AgentAdapter):
+        supports_sessions = True
+
+        def __init__(self) -> None:
+            self.session = StubSession()
+
+        async def ainvoke(self, prompt: str, metadata: dict | None = None) -> str:
+            return prompt
+
+        async def open_session(self, context: SessionContext):
+            return self.session
+
+    ExecutionContext.get().reset()
+    adapter = StubAdapter()
+    adapter_config = AdapterConfig(
+        type=AdapterType.PYTHON,
+        name="stub",
+        system_prompt="",
+    )
+    student_config = StudentConfig(
+        prompts=StudentPrompts(
+            planner="Plan",
+            executor="Execute",
+            synthesizer="Synthesize",
+        )
+    )
+    student_prompts = build_student_prompts(adapter_config.system_prompt, student_config)
+    student = Student(adapter, adapter_config, student_config, student_prompts)
+
+    task = "Test"
+    async with student.session_scope(task, "stepwise"):
+        plan = await student.acreate_plan(task)
+        assert plan.steps
+        answer = await student.asynthesize_final_answer(task, [])
+        assert answer == "Final answer"
+
+    session_meta = ExecutionContext.get().metadata.get("adapter_session")
+    assert isinstance(session_meta, dict)
+    assert session_meta.get("adapter_session_id") == "stub-session"
+    usage_meta = session_meta.get("usage")
+    assert isinstance(usage_meta, dict)
+    assert usage_meta.get("calls", 0) >= 2
+    events_meta = session_meta.get("events")
+    assert isinstance(events_meta, list)
+

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -10,6 +10,11 @@ from atlas.runtime.storage.database import Database
 from atlas.types import Plan, Step, StepEvaluation, StepResult
 
 
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
 class FakeConnection:
     def __init__(self):
         self.commands = []
@@ -58,7 +63,7 @@ class FakePool:
         pass
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio("asyncio")
 async def test_database_logs_plan_steps(monkeypatch):
     pool = FakePool()
     import asyncpg

--- a/tests/unit/test_probe_eval.py
+++ b/tests/unit/test_probe_eval.py
@@ -11,6 +11,11 @@ from scripts import export_probe_dataset as probe_export
 from scripts.eval_probe_models import ProbeResult, ProbeSample, summarise_results
 
 
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
 def test_load_dataset_sample() -> None:
     path = Path("atlas/data/sample_probe_payloads.jsonl")
     samples = probe_eval.load_dataset(path)
@@ -27,7 +32,7 @@ def test_build_parameters_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
     assert params.provider.value == "google"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio("asyncio")
 async def test_evaluate_model_with_stub(monkeypatch: pytest.MonkeyPatch) -> None:
     async def fake_arun(self, *, task, dossier, execution_metadata):
         class Decision:
@@ -73,7 +78,7 @@ def test_export_helpers_extract_learning_key() -> None:
     assert probe_export._expected_mode({"adaptive_summary": {"adaptive_mode": "auto"}}) == "auto"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio("asyncio")
 async def test_export_probe_dataset_writes_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     class FakeDatabase:
         call_counts = 0

--- a/tests/unit/test_prompt_builders.py
+++ b/tests/unit/test_prompt_builders.py
@@ -49,7 +49,7 @@ def test_build_teacher_prompts_default_templates_include_base_prompt():
     prompts = build_teacher_prompts("Base prompt", teacher_cfg)
     assert isinstance(prompts, RewrittenTeacherPrompts)
     assert prompts.plan_review.startswith("Base prompt")
-    assert "JSON schema reference for plan review responses" in prompts.plan_review
+    assert "Return JSON only." in prompts.plan_review
     assert prompts.validation.startswith("Base prompt")
     assert prompts.guidance.startswith("Base prompt")
-    assert "JSON schema reference for validation responses" in prompts.validation
+    assert "Return JSON only." in prompts.validation

--- a/tests/unit/test_reward_eval.py
+++ b/tests/unit/test_reward_eval.py
@@ -19,6 +19,11 @@ from scripts.eval_reward_models import (
 )
 
 
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
 def test_load_reward_dataset_shapes():
     records = load_reward_dataset(path=Path("atlas/data/reward_eval_trajectories.jsonl"))
     assert len(records) >= 6
@@ -96,7 +101,7 @@ class _StubEvaluator:
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio("asyncio")
 async def test_evaluate_combo_and_aggregate_with_stub(monkeypatch):
     records = load_reward_dataset(Path("atlas/data/reward_eval_trajectories.jsonl"))[:2]
     config = load_config("configs/examples/openai_agent.yaml")


### PR DESCRIPTION
This pull request introduces session-aware adapter support to the Atlas connectors framework, enabling adapters to maintain state across multiple steps within a session. The changes add a protocol for stateful adapters, update metadata handling to track session information, and extend Python, HTTP, and OpenAI adapters to support session IDs and session lifecycle hooks. Additionally, usage and event metrics are now tracked per session. Below are the most important changes grouped by theme:

**Session-aware adapter protocol and Python adapter enhancements:**

* Added a session protocol for adapters, allowing them to implement stateful behavior via `open_session`, `step`, and `close` methods, with automatic fallback to stateless mode for legacy adapters. The `SessionResourcePool` class was introduced to help share resources across sessions. (`atlas/connectors/README.md`, `atlas/connectors/python.py`) [[1]](diffhunk://#diff-40c676d8d0f03353263a26370a59d8846508f886c398e0943587c1c669d7d9b6R24-R64) [[2]](diffhunk://#diff-293dcbeab01dd09a9be76c3be6bb8a38024eb2add071f187b0dd67cda0d306d6L10-R146) [[3]](diffhunk://#diff-293dcbeab01dd09a9be76c3be6bb8a38024eb2add071f187b0dd67cda0d306d6R164-R180) [[4]](diffhunk://#diff-293dcbeab01dd09a9be76c3be6bb8a38024eb2add071f187b0dd67cda0d306d6R198-R228) [[5]](diffhunk://#diff-293dcbeab01dd09a9be76c3be6bb8a38024eb2add071f187b0dd67cda0d306d6R238-R248)
* Python adapters now detect session-aware classes by looking for `on_open`, `on_step`, and `on_close` hooks, and wrap them in a session lifecycle that manages state and metadata. (`atlas/connectors/python.py`) [[1]](diffhunk://#diff-293dcbeab01dd09a9be76c3be6bb8a38024eb2add071f187b0dd67cda0d306d6L10-R146) [[2]](diffhunk://#diff-293dcbeab01dd09a9be76c3be6bb8a38024eb2add071f187b0dd67cda0d306d6R164-R180) [[3]](diffhunk://#diff-293dcbeab01dd09a9be76c3be6bb8a38024eb2add071f187b0dd67cda0d306d6R198-R228) [[4]](diffhunk://#diff-293dcbeab01dd09a9be76c3be6bb8a38024eb2add071f187b0dd67cda0d306d6R238-R248)

**Session metadata propagation and enrichment:**

* Session and step payloads are now enriched with `adapter_session_id`, `adapter_usage`, and `adapter_events` fields, ensuring session information is tracked and available throughout the execution flow. (`atlas/cli/jsonl_writer.py`) [[1]](diffhunk://#diff-1c90985b8f5216690672427754c7afa02c9ebd49b5ddd3c3b6670f89b6b266b1R351-R362) [[2]](diffhunk://#diff-1c90985b8f5216690672427754c7afa02c9ebd49b5ddd3c3b6670f89b6b266b1R406-R414)

**Session support in HTTP and OpenAI adapters:**

* HTTP and OpenAI adapters now propagate session IDs via payloads and headers, allowing backend services to correlate requests to the same session. (`atlas/connectors/http.py`, `atlas/connectors/openai.py`) [[1]](diffhunk://#diff-a9030a8b601acda10cab28c8676ac9fd1f528de398face027ea7f6d5855cf6b5L28-R33) [[2]](diffhunk://#diff-c5028eb5e73c1a444ad90f8ed907d040db25870e0951ce2800abd94b52fdb215R176-R182)

**Session-aware orchestration and metrics tracking:**

* The LangChain bridge and orchestration code now invoke adapter sessions when available, and update session metrics such as usage and events, with support for event bucketing and limits. (`atlas/connectors/langchain_bridge.py`) [[1]](diffhunk://#diff-3cb83a09fae44bbf1d8f3ea5cf2a268e0b2aacb568c617337d8c064cbccb35b9R37-R74) [[2]](diffhunk://#diff-3cb83a09fae44bbf1d8f3ea5cf2a268e0b2aacb568c617337d8c064cbccb35b9L82-R130) [[3]](diffhunk://#diff-3cb83a09fae44bbf1d8f3ea5cf2a268e0b2aacb568c617337d8c064cbccb35b9L204-R272)

**Documentation updates:**

* The `atlas/connectors/README.md` file was updated to document the new session protocol, usage patterns, and Python adapter hooks, including a reference to a stateful SQL adapter example.

These changes collectively enable adapters to maintain state across multiple invocations, improve observability of adapter usage, and provide a consistent protocol for session management in Atlas.

Resolves #58