### PR TITLE
chore: improve reward eval harness auditing

### DIFF
--- a/atlas/runtime/storage/database.py
+++ b/atlas/runtime/storage/database.py
@@ -139,11 +139,11 @@ class Database:
                 step_id,
             )
             records = [(session_id, step_id, index, note) for index, note in enumerate(notes, start=1)]
-        if records:
-            await connection.executemany(
-                "INSERT INTO guidance_notes(session_id, step_id, sequence, note) VALUES ($1, $2, $3, $4)",
-                records,
-            )
+            if records:
+                await connection.executemany(
+                    "INSERT INTO guidance_notes(session_id, step_id, sequence, note) VALUES ($1, $2, $3, $4)",
+                    records,
+                )
 
     async def log_discovery_run(
         self,

--- a/configs/eval/reward_system.yaml
+++ b/configs/eval/reward_system.yaml
@@ -1,0 +1,69 @@
+presets:
+  gemini-2.5-flash:
+    provider: GEMINI
+    model: gemini/gemini-2.5-flash
+    api_key_env: GEMINI_API_KEY
+    temperature: 0.2
+    timeout_seconds: 60.0
+    max_output_tokens: 8096
+  gemini-2.5-pro:
+    provider: GEMINI
+    model: gemini/gemini-2.5-pro
+    api_key_env: GEMINI_API_KEY
+    temperature: 0.2
+    timeout_seconds: 60.0
+    max_output_tokens: 8096
+  claude-haiku-4-5:
+    provider: ANTHROPIC
+    model: claude-haiku-4-5
+    api_key_env: ANTHROPIC_API_KEY
+    temperature: 0.2
+    timeout_seconds: 60.0
+  claude-sonnet-4-5-20250929:
+    provider: ANTHROPIC
+    model: claude-sonnet-4-5-20250929
+    api_key_env: ANTHROPIC_API_KEY
+    temperature: 0.15
+    timeout_seconds: 60.0
+  grok-4-fast:
+    provider: XAI
+    model: xai/grok-4-fast
+    api_key_env: XAI_API_KEY
+    temperature: 0.2
+    timeout_seconds: 45.0
+  grok-4:
+    provider: XAI
+    model: xai/grok-4
+    api_key_env: XAI_API_KEY
+    temperature: 0.2
+    timeout_seconds: 60.0
+  gpt-5-mini:
+    provider: OPENAI
+    model: gpt-5-mini
+    api_key_env: OPENAI_API_KEY
+    temperature: 0.2
+    timeout_seconds: 60.0
+  gpt-5:
+    provider: OPENAI
+    model: gpt-5
+    api_key_env: OPENAI_API_KEY
+    temperature: 0.2
+    timeout_seconds: 60.0
+
+combos:
+  gemini_pair:
+    small_preset: gemini-2.5-flash
+    large_preset: gemini-2.5-pro
+    description: "Gemini Flash (small) ➜ Gemini Pro (arbiter)"
+  claude_stack:
+    small_preset: claude-haiku-4-5
+    large_preset: claude-sonnet-4-5-20250929
+    description: "Claude Haiku ➜ Claude Sonnet"
+  gpt5_stack:
+    small_preset: gpt-5-mini
+    large_preset: gpt-5
+    description: "GPT-5 Mini ➜ GPT-5"
+  grok_stack:
+    small_preset: grok-4-fast
+    large_preset: grok-4
+    description: "Grok 4 Fast ➜ Grok 4"


### PR DESCRIPTION
## Summary
- add `configs/eval/reward_system.yaml` so judge presets/combos can be edited without touching code, falling back to baked-in defaults if missing
- extend `scripts/eval_reward_models.py` with a `--collect-audit` flag, safe audit payload serialization, and automatic Markdown report emission alongside JSON output
- document the new flags and config-driven workflow in `docs/reward_eval.md`

## Testing
- `python -m scripts.eval_reward_models --dataset atlas/data/reward_eval_trajectories.jsonl --judge-combos gemini_pair --baseline gemini_pair --repeats 1 --concurrency 1 --collect-audit --output results/reward/latest_gemini.json`
