### PR TITLE
docs: add training pipeline documentation links

### DIFF
--- a/docs/examples/export_runtime_traces.md
+++ b/docs/examples/export_runtime_traces.md
@@ -61,6 +61,24 @@ The exported file slots directly into the Atlas core training stack:
 1. Run `atlas.core.run(...)` to generate sessions and persist them to PostgreSQL.
 2. Review new sessions with `arc-atlas review sessions --database-url ...`, then approve them with `arc-atlas review approve <id>`.
 3. Execute `arc-atlas --database-url ... --output traces.jsonl` (or `python -m atlas.cli.export ...`).
-3. In the core repository, call `load_runtime_traces("traces.jsonl")` or `flatten_traces_for_training(...)` from `trainers/runtime_dataset.py`.
+4. In the core repository, call `load_runtime_traces("traces.jsonl")` or `flatten_traces_for_training(...)` from `trainers/runtime_dataset.py`.
 
 This workflow keeps runtime telemetry decoupled from training data generation while reusing the shared schema consumed by the core trainers.
+
+---
+
+## Next Steps: Training
+
+Runtime traces feed the offline training pipeline in [Atlas Core](https://github.com/Arc-Computer/ATLAS):
+
+- [Complete Training Pipeline](https://docs.arc.computer/training/offline/grpo-training) - Step-by-step SFT → GRPO workflow
+- [Training Configuration](https://docs.arc.computer/training/configuration) - Hydra parameters reference
+- [Training Data Pipeline](https://docs.arc.computer/training/offline/training-data-pipeline) - Direct database access API (recommended over JSONL export)
+- [GKD Training](https://docs.arc.computer/training/offline/gkd-training) - Fast distillation (9-30x faster than GRPO)
+
+**Training methods:**
+- **GRPO** - Reinforcement learning from reward signals
+- **GKD** - Fast distillation for production models
+- **SFT** - Supervised fine-tuning on approved traces
+
+Trained checkpoints deploy back into SDK agents by updating your runtime config's `teacher.model_name_or_path`.

--- a/docs/operations/guardrails.md
+++ b/docs/operations/guardrails.md
@@ -104,3 +104,21 @@ runtime_safety:
 When `require_approval` is set to `false`, Atlas automatically marks sessions as `approved` once they finish (drift alerts still return them to `pending`). Pass `--config` to `arc-atlas` so the exporter loads these defaults, and use `ATLAS_REVIEW_REQUIRE_APPROVAL=0` or `ATLAS_REVIEW_DEFAULT_EXPORT_STATUSES="approved,pending"` for quick one-off overrides.
 
 Set `ATLAS_DRIFT_WINDOW`, `ATLAS_DRIFT_Z_THRESHOLD`, or `ATLAS_DRIFT_MIN_BASELINE` to experiment without editing config. `ATLAS_REVIEW_DEFAULT_EXPORT_STATUSES="approved,pending"` relaxes the default export gate for developer workflows, and `ATLAS_REVIEW_REQUIRE_APPROVAL=0` disables the auto-approval requirement entirely (use with care in production).
+
+---
+
+## Next Steps: Training
+
+Approved sessions feed the offline training pipeline in [Atlas Core](https://github.com/Arc-Computer/ATLAS):
+
+- [Complete Training Pipeline](https://docs.arc.computer/training/offline/grpo-training) - Step-by-step SFT → GRPO workflow
+- [Training Configuration](https://docs.arc.computer/training/configuration) - Hydra parameters reference
+- [Training Data Pipeline](https://docs.arc.computer/training/offline/training-data-pipeline) - Direct database access API
+- [GKD Training](https://docs.arc.computer/training/offline/gkd-training) - Fast distillation (9-30x faster than GRPO)
+
+**Typical workflow:**
+1. Collect traces with SDK runtime
+2. Review/approve sessions (`arc-atlas review`)
+3. Train updated model in Core (GRPO/GKD/SFT)
+4. Deploy checkpoint back to SDK agents
+5. Repeat


### PR DESCRIPTION
Resolves #124 and #126

## Changes

Added targeted signposting to Atlas Core training documentation to improve discoverability:

1. **README.md** - Enhanced "Training Your Model" section with:
   - Clear links to GRPO, GKD, and SFT training guides
   - Quick start examples for both direct database access and JSONL export
   - Links to comprehensive Core documentation

2. **docs/operations/guardrails.md** - Added "Next Steps: Training" section with:
   - Links to complete training pipeline
   - Training configuration reference
   - Typical workflow overview

3. **docs/examples/export_runtime_traces.md** - Added "Next Steps: Training" section with:
   - Training pipeline links
   - Training methods overview
   - Checkpoint deployment guidance

## Approach

This PR addresses the issue through minimal, targeted documentation additions rather than duplicating Core documentation. All changes point to existing comprehensive training documentation at docs.arc.computer.

## Impact

SDK users can now easily discover the training pipeline and navigate to Core documentation when they're ready to train custom models.